### PR TITLE
Add experimental Java profiling instrumentation

### DIFF
--- a/instrumentation/profiling/README.md
+++ b/instrumentation/profiling/README.md
@@ -1,6 +1,6 @@
 # Settings for the Profiling instrumentation
 
-This instrumentation is experimental and currently targets Java 17+ JVMs with JFR available.
+This instrumentation is experimental and currently targets Java 11+ JVMs with JFR available.
 
 The first implementation focuses on:
 

--- a/instrumentation/profiling/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/profiling/ProfilingInstaller.java
+++ b/instrumentation/profiling/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/profiling/ProfilingInstaller.java
@@ -40,7 +40,7 @@ public class ProfilingInstaller implements AgentListener {
     }
     if (!JfrSupport.isJfrAvailable()) {
       logger.warning(
-          "Profiling is enabled but JFR is unavailable. Profiling currently requires Java 17+ with JFR available.");
+          "Profiling is enabled but JFR is unavailable. Profiling currently requires Java 11+ with JFR available.");
       return;
     }
 

--- a/instrumentation/profiling/library/build.gradle.kts
+++ b/instrumentation/profiling/library/build.gradle.kts
@@ -1,10 +1,19 @@
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+
 plugins {
   id("otel.library-instrumentation")
 }
 
-val mrJarVersions = listOf(17)
+val mrJarVersions = listOf(11, 17)
+val javaToolchainService = project.extensions.getByType(JavaToolchainService::class.java)
 
 sourceSets {
+  create("testJava11") {
+    java {
+      setSrcDirs(listOf("src/testJava11/java"))
+    }
+  }
   create("testJava17") {
     java {
       setSrcDirs(listOf("src/testJava17/java"))
@@ -44,6 +53,12 @@ for (version in mrJarVersions) {
 }
 
 configurations {
+  named("testJava11Implementation") {
+    extendsFrom(configurations["testImplementation"])
+  }
+  named("testJava11RuntimeOnly") {
+    extendsFrom(configurations["testRuntimeOnly"])
+  }
   named("testJava17Implementation") {
     extendsFrom(configurations["testImplementation"])
   }
@@ -53,12 +68,23 @@ configurations {
 }
 
 dependencies {
+  add("testJava11Implementation", sourceSets.test.get().output)
+  add("testJava11Implementation", sourceSets["java11"].output)
+  add("testJava11Implementation", sourceSets.main.get().output)
   add("testJava17Implementation", sourceSets.test.get().output)
+  add("testJava17Implementation", sourceSets["java11"].output)
   add("testJava17Implementation", sourceSets["java17"].output)
   add("testJava17Implementation", sourceSets.main.get().output)
 }
 
 tasks {
+  named<JavaCompile>("compileTestJava11Java") {
+    dependsOn("compileJava11Java")
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
+    options.release.set(11)
+  }
+
   named<JavaCompile>("compileTestJava17Java") {
     dependsOn("compileJava17Java")
     sourceCompatibility = "17"
@@ -83,15 +109,36 @@ tasks {
     manifest.attributes("Multi-Release" to "true")
   }
 
+  val testJava11 by registering(Test::class) {
+    dependsOn("compileTestJava11Java")
+    testClassesDirs = sourceSets["testJava11"].output.classesDirs
+    classpath = sourceSets["testJava11"].runtimeClasspath
+    javaLauncher.set(
+      javaToolchainService.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(11))
+      }
+    )
+  }
+
   val testJava17 by registering(Test::class) {
     dependsOn("compileTestJava17Java")
     testClassesDirs = sourceSets["testJava17"].output.classesDirs
     classpath = sourceSets["testJava17"].runtimeClasspath
+    javaLauncher.set(
+      javaToolchainService.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+      }
+    )
   }
 
   val testJavaVersion =
     gradle.startParameter.projectProperties.get("testJavaVersion")?.let(JavaVersion::toVersion)
       ?: JavaVersion.current()
+  if (!testJavaVersion.isCompatibleWith(JavaVersion.VERSION_11)) {
+    named("testJava11", Test::class).configure {
+      enabled = false
+    }
+  }
   if (!testJavaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
     named("testJava17", Test::class).configure {
       enabled = false
@@ -99,6 +146,7 @@ tasks {
   }
 
   check {
+    dependsOn(testJava11)
     dependsOn(testJava17)
   }
 }

--- a/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrProfileSnapshot.java
+++ b/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrProfileSnapshot.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.profiling.internal;
+
+import io.opentelemetry.instrumentation.profiling.ProfileSnapshot;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import jdk.jfr.Recording;
+
+final class JfrProfileSnapshot implements ProfileSnapshot {
+
+  private final Recording recording;
+  private final Instant startTime;
+  private final Instant endTime;
+
+  private JfrProfileSnapshot(Recording recording, Instant startTime, Instant endTime) {
+    this.recording = recording;
+    this.startTime = startTime;
+    this.endTime = endTime;
+  }
+
+  static JfrProfileSnapshot create(Recording snapshot, Instant startTime) {
+    Instant endTime = snapshot.getStopTime() != null ? snapshot.getStopTime() : Instant.now();
+    return new JfrProfileSnapshot(snapshot, startTime, endTime);
+  }
+
+  @Override
+  public Instant getStartTime() {
+    return startTime;
+  }
+
+  @Override
+  public Instant getEndTime() {
+    return endTime;
+  }
+
+  @Override
+  public String getFormat() {
+    return "jfr";
+  }
+
+  @Override
+  public InputStream openStream() throws IOException {
+    return recording.getStream(startTime, endTime);
+  }
+
+  @Override
+  public void close() {
+    recording.close();
+  }
+}

--- a/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrRecordingSession.java
+++ b/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrRecordingSession.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.profiling.internal;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import jdk.jfr.Configuration;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Recording;
+
+final class JfrRecordingSession implements AutoCloseable {
+
+  private final Recording recording;
+
+  JfrRecordingSession(ProfilingConfig config) {
+    this.recording = createRecording(config);
+  }
+
+  void start() {
+    recording.start();
+  }
+
+  JfrProfileSnapshot snapshot(Instant startTime) {
+    Recording snapshot = FlightRecorder.getFlightRecorder().takeSnapshot();
+    snapshot.setName(recording.getName());
+    return JfrProfileSnapshot.create(snapshot, startTime);
+  }
+
+  JfrProfileSnapshot stop(Instant startTime) {
+    recording.stop();
+    return JfrProfileSnapshot.create(recording, startTime);
+  }
+
+  @Override
+  public void close() {
+    recording.close();
+  }
+
+  private static Recording createRecording(ProfilingConfig config) {
+    Recording recording = new Recording();
+    recording.setName("otel-profiling");
+    recording.setToDisk(true);
+    if (config.getMaxSize() > 0) {
+      recording.setMaxSize(config.getMaxSize());
+    }
+    recording.setMaxAge(config.getMaxAge());
+    try {
+      recording.setSettings(createSettings(config));
+    } catch (IOException | ParseException exception) {
+      throw new IllegalStateException("Unable to load JFR profile configuration", exception);
+    }
+    return recording;
+  }
+
+  static Map<String, String> createSettings(ProfilingConfig config)
+      throws IOException, ParseException {
+    Map<String, String> settings =
+        new HashMap<>(Configuration.getConfiguration("profile").getSettings());
+    applyMemorySettings(settings, config);
+    return settings;
+  }
+
+  private static void applyMemorySettings(Map<String, String> settings, ProfilingConfig config) {
+    applyBooleanSetting(
+        settings,
+        "jdk.ObjectAllocationInNewTLAB#enabled",
+        config,
+        config.getMemoryAllocationSampling());
+    applyBooleanSetting(
+        settings,
+        "jdk.ObjectAllocationOutsideTLAB#enabled",
+        config,
+        config.getMemoryAllocationSampling());
+    applyBooleanSetting(
+        settings,
+        "jdk.ObjectAllocationSample#enabled",
+        config,
+        config.getMemoryAllocationSampling());
+    applyBooleanSetting(
+        settings, "jdk.OldObjectSample#enabled", config, config.getMemoryOldObjectSampling());
+    applyDefaultMemorySetting(settings, "jdk.ObjectCount#enabled", config);
+    applyDefaultMemorySetting(settings, "jdk.ObjectCountAfterGC#enabled", config);
+    applyDefaultMemorySetting(settings, "jdk.NativeMemoryUsage#enabled", config);
+    applyDefaultMemorySetting(settings, "jdk.NativeMemoryUsageTotal#enabled", config);
+    applyDefaultMemorySetting(settings, "jdk.GCHeapSummary#enabled", config);
+  }
+
+  private static void applyBooleanSetting(
+      Map<String, String> settings, String settingName, ProfilingConfig config, Boolean value) {
+    if (!config.isMemoryEnabled() && value == null) {
+      return;
+    }
+    settings.put(settingName, Boolean.toString(value != null ? value : config.isMemoryEnabled()));
+  }
+
+  private static void applyDefaultMemorySetting(
+      Map<String, String> settings, String settingName, ProfilingConfig config) {
+    if (config.isMemoryEnabled()) {
+      settings.put(settingName, "true");
+    }
+  }
+}

--- a/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrRuntimeProfiling.java
+++ b/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrRuntimeProfiling.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.profiling.internal;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+
+import io.opentelemetry.instrumentation.profiling.ProfileExporterAdapter;
+import io.opentelemetry.instrumentation.profiling.ProfileSnapshot;
+import io.opentelemetry.instrumentation.profiling.RuntimeProfiling;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+final class JfrRuntimeProfiling implements RuntimeProfiling {
+
+  private static final Logger logger = Logger.getLogger(JfrRuntimeProfiling.class.getName());
+
+  private final ProfilingConfig config;
+  private final ProfileExporterAdapter exporterAdapter;
+  private final ProfilingScheduler scheduler =
+      new ProfilingScheduler("OpenTelemetry Profiling Runner");
+  private final AtomicBoolean started = new AtomicBoolean();
+  private final AtomicBoolean closed = new AtomicBoolean();
+  private final AtomicBoolean exported = new AtomicBoolean();
+
+  private volatile JfrRecordingSession recordingSession;
+  private volatile Instant lastSnapshotStart;
+
+  JfrRuntimeProfiling(ProfilingConfig config, ProfileExporterAdapter exporterAdapter) {
+    this.config = config;
+    this.exporterAdapter = exporterAdapter;
+  }
+
+  @Override
+  public void start() {
+    if (!started.compareAndSet(false, true)) {
+      return;
+    }
+
+    long startupDelayMillis = config.getStartupDelay().toMillis();
+    if (startupDelayMillis == 0) {
+      startRecording();
+    } else {
+      scheduler.schedule(this::startRecording, startupDelayMillis, MILLISECONDS);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+
+    scheduler.close();
+    if (exported.get()) {
+      closeRecordingSession();
+    } else {
+      exportFinalRecording();
+    }
+  }
+
+  private void startRecording() {
+    if (closed.get()) {
+      return;
+    }
+
+    try {
+      JfrRecordingSession session = new JfrRecordingSession(config);
+      session.start();
+      recordingSession = session;
+      lastSnapshotStart = Instant.now();
+      long intervalMillis = config.getInterval().toMillis();
+      scheduler.scheduleAtFixedRate(
+          this::exportSnapshot, intervalMillis, intervalMillis, MILLISECONDS);
+    } catch (RuntimeException exception) {
+      logger.log(WARNING, "Unable to start JFR profiling session", exception);
+      closeRecordingSession();
+    }
+  }
+
+  private void exportSnapshot() {
+    exportCurrentRecording(false);
+  }
+
+  private void exportFinalRecording() {
+    exportCurrentRecording(true);
+  }
+
+  private void exportCurrentRecording(boolean finalExport) {
+    JfrRecordingSession session = recordingSession;
+    if (session == null) {
+      return;
+    }
+    if (finalExport) {
+      recordingSession = null;
+    }
+
+    Instant snapshotStart = lastSnapshotStart != null ? lastSnapshotStart : Instant.now();
+    try (ProfileSnapshot snapshot =
+        finalExport ? session.stop(snapshotStart) : session.snapshot(snapshotStart)) {
+      lastSnapshotStart = snapshot.getEndTime().plusNanos(1);
+      exporterAdapter.export(snapshot);
+      exported.set(true);
+    } catch (Exception exception) {
+      if (isMissingChunks(exception)) {
+        logger.log(
+            FINE,
+            finalExport
+                ? "Skipping final profiling snapshot because JFR has not produced chunks yet"
+                : "Skipping profiling snapshot because JFR has not produced chunks yet");
+        return;
+      }
+      logger.log(
+          WARNING,
+          finalExport
+              ? "Unable to export final profiling snapshot"
+              : "Unable to export profiling snapshot",
+          exception);
+    } finally {
+      if (finalExport) {
+        session.close();
+      }
+    }
+  }
+
+  private void closeRecordingSession() {
+    JfrRecordingSession session = recordingSession;
+    recordingSession = null;
+    if (session != null) {
+      session.close();
+    }
+  }
+
+  private static boolean isMissingChunks(Throwable throwable) {
+    for (Throwable current = throwable; current != null; current = current.getCause()) {
+      String message = current.getMessage();
+      if (message != null
+          && (message.contains("No chunks") || message.contains("Missing chunkfile"))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrSupport.java
+++ b/instrumentation/profiling/library/src/main/java11/io/opentelemetry/instrumentation/profiling/internal/JfrSupport.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.profiling.internal;
+
+import io.opentelemetry.instrumentation.profiling.ProfileExporterAdapter;
+import io.opentelemetry.instrumentation.profiling.RuntimeProfiling;
+import jdk.jfr.FlightRecorder;
+
+/**
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
+ */
+public final class JfrSupport {
+
+  public static RuntimeProfiling build(
+      ProfilingConfig config,
+      ProfileExporterAdapter exporterAdapter) {
+    if (!isJfrAvailable()) {
+      return NoopRuntimeProfiling.INSTANCE;
+    }
+    return new JfrRuntimeProfiling(config, exporterAdapter);
+  }
+
+  public static boolean isJfrAvailable() {
+    try {
+      return FlightRecorder.isAvailable();
+    } catch (Throwable ignored) {
+      return false;
+    }
+  }
+
+  private JfrSupport() {}
+}

--- a/instrumentation/profiling/library/src/testJava11/java/io/opentelemetry/instrumentation/profiling/internal/JfrRecordingSessionTest.java
+++ b/instrumentation/profiling/library/src/testJava11/java/io/opentelemetry/instrumentation/profiling/internal/JfrRecordingSessionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.profiling.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import io.opentelemetry.instrumentation.profiling.ProfileSnapshot;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import jdk.jfr.FlightRecorder;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JfrRecordingSessionTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void canSnapshotRecording() throws Exception {
+    Assumptions.assumeTrue(JfrSupport.isJfrAvailable(), "JFR not available");
+    Assumptions.assumeTrue(FlightRecorder.isAvailable(), "JFR not available");
+
+    ProfilingConfig config =
+        new ProfilingConfig(
+            Duration.ofSeconds(1),
+            Duration.ZERO,
+            Duration.ofMinutes(5),
+            0,
+            64,
+            tempDir,
+            true,
+            Boolean.TRUE,
+            Boolean.TRUE);
+    Map<String, String> settings = JfrRecordingSession.createSettings(config);
+    assertEquals("true", settings.get("jdk.ObjectAllocationSample#enabled"));
+    assertEquals("true", settings.get("jdk.ObjectCount#enabled"));
+    assertEquals("true", settings.get("jdk.ObjectCountAfterGC#enabled"));
+    assertEquals("true", settings.get("jdk.NativeMemoryUsage#enabled"));
+    assertEquals("true", settings.get("jdk.NativeMemoryUsageTotal#enabled"));
+    assertEquals("true", settings.get("jdk.GCHeapSummary#enabled"));
+
+    try (JfrRecordingSession session = new JfrRecordingSession(config)) {
+      session.start();
+
+      for (int i = 0; i < 100_000; i++) {
+        Math.log(i + 1);
+      }
+
+      try (ProfileSnapshot snapshot = session.snapshot(Instant.now().minusSeconds(1));
+          InputStream stream = snapshot.openStream()) {
+        assertEquals("jfr", snapshot.getFormat());
+        assertNotEquals(-1, stream.read());
+      }
+    }
+  }
+
+  @Test
+  void memorySettingsOverrideProfileDefaults() throws Exception {
+    Assumptions.assumeTrue(JfrSupport.isJfrAvailable(), "JFR not available");
+    Assumptions.assumeTrue(FlightRecorder.isAvailable(), "JFR not available");
+
+    ProfilingConfig config =
+        new ProfilingConfig(
+            Duration.ofSeconds(1),
+            Duration.ZERO,
+            Duration.ofMinutes(5),
+            0,
+            64,
+            tempDir,
+            false,
+            Boolean.TRUE,
+            Boolean.FALSE);
+    Map<String, String> settings = JfrRecordingSession.createSettings(config);
+
+    assertEquals("true", settings.get("jdk.ObjectAllocationSample#enabled"));
+    assertEquals("true", settings.get("jdk.ObjectAllocationInNewTLAB#enabled"));
+    assertEquals("true", settings.get("jdk.ObjectAllocationOutsideTLAB#enabled"));
+    assertEquals("false", settings.get("jdk.OldObjectSample#enabled"));
+  }
+}

--- a/instrumentation/profiling/metadata.yaml
+++ b/instrumentation/profiling/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  EXPERIMENTAL: This instrumentation enables JVM profiling using Java Flight Recorder (Java 17+)
+  EXPERIMENTAL: This instrumentation enables JVM profiling using Java Flight Recorder (Java 11+)
   and can periodically emit profiling snapshots.
 library_link: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/profiling
 configurations:


### PR DESCRIPTION
## Summary

  This change adds an experimental Java profiling instrumentation for the javaagent.

  ### Included

  - add `instrumentation/profiling/library`
  - add `instrumentation/profiling/javaagent`
  - start continuous JFR-based profiling on Java 17+ JVMs
  - export JFR snapshots through pluggable adapters
  - add Datakit profile exporter using `multipart/form-data`
  - add file exporter for validation/debugging
  - support `otel.profiling.*` config and legacy compatibility aliases
  - support memory profiling overlay options
  - add library tests, Java 17 JFR tests, file exporter agent test, and Datakit exporter agent test

  ### Notes

  - profiling currently requires Java 17+ with JFR available
  - JDK 8 runtime does not support this profiling implementation
  - trace export code path is not changed in this PR
