### PR TITLE
Add application meta exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ For a detailed list of agent configuration options, see the [agent configuration
 For a detailed list of additional SDK configuration environment variables and system properties,
 see the [SDK configuration docs][config-sdk].
 
+The Guance distribution also provides a dedicated [Meta exporter](docs/meta-exporter.md) for agent
+and application runtime metadata.
+
 _Note: Config parameter names are very likely to change over time, so please check
 back here when trying out a new version!
 Please [report any bugs](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues)

--- a/docs/meta-exporter.md
+++ b/docs/meta-exporter.md
@@ -1,0 +1,246 @@
+# Meta exporter
+
+The Guance Java agent can export agent and application runtime metadata through a dedicated HTTP
+pipeline. Meta data is independent of the OpenTelemetry trace, metric, and log exporters.
+
+The exporter reports application startup, loaded dependencies, applied Java agent instrumentations,
+and process heartbeats. These events share one process-level `runtime_id` and the same resource
+metadata. Dependency and integration payloads are full current-state snapshots, not increments.
+
+## Configuration
+
+Meta export is disabled by default. Enable it by selecting the `meta` exporter and configuring an
+explicit endpoint:
+
+```properties
+otel.meta.exporter=meta
+otel.exporter.meta.endpoint=https://example.com/v1/meta
+```
+
+Available properties:
+
+| System property                               | Environment variable                          | Default | Description                                  |
+| --------------------------------------------- | --------------------------------------------- | ------- | -------------------------------------------- |
+| `otel.meta.exporter`                          | `OTEL_META_EXPORTER`                          | `none`  | Meta exporter: `none` or `meta`.             |
+| `otel.exporter.meta.endpoint`                 | `OTEL_EXPORTER_META_ENDPOINT`                 | none    | Complete HTTP or HTTPS destination URL.      |
+| `otel.exporter.meta.headers`                  | `OTEL_EXPORTER_META_HEADERS`                  | none    | Comma-separated request headers.             |
+| `otel.exporter.meta.timeout`                  | `OTEL_EXPORTER_META_TIMEOUT`                  | `10000` | Connect and read timeout in milliseconds.    |
+| `otel.exporter.meta.compression`              | `OTEL_EXPORTER_META_COMPRESSION`              | `none`  | Request compression: `none` or `gzip`.       |
+| `otel.exporter.meta.max-retries`              | `OTEL_EXPORTER_META_MAX_RETRIES`              | `3`     | Maximum retries after the initial request.   |
+| `otel.exporter.meta.max-request-size`         | `OTEL_EXPORTER_META_MAX_REQUEST_SIZE`         | `5242880` | Maximum serialized request size in bytes.  |
+| `otel.meta.batch.schedule-delay`              | `OTEL_META_BATCH_SCHEDULE_DELAY`              | `1000`  | Event batching window in milliseconds.       |
+| `otel.meta.shutdown-timeout`                  | `OTEL_META_SHUTDOWN_TIMEOUT`                  | `10000` | Maximum time shutdown waits for the worker, in milliseconds. |
+| `otel.meta.heartbeat.interval`                 | `OTEL_META_HEARTBEAT_INTERVAL`                 | `60000` | Lightweight heartbeat interval in milliseconds. |
+| `otel.meta.extended-heartbeat.interval`        | `OTEL_META_EXTENDED_HEARTBEAT_INTERVAL`        | `86400000` | Full-state heartbeat interval in milliseconds. |
+| `otel.meta.app-started.enabled`               | `OTEL_META_APP_STARTED_ENABLED`               | `true`  | Emit the `app-started` event.                |
+| `otel.meta.app-dependencies-loaded.enabled`   | `OTEL_META_APP_DEPENDENCIES_LOADED_ENABLED`   | `true`  | Discover and emit loaded application JARs.   |
+| `otel.meta.app-integrations-change.enabled`   | `OTEL_META_APP_INTEGRATIONS_CHANGE_ENABLED`   | `true`  | Emit successfully applied instrumentations. |
+
+Meta never inherits the generic OTLP endpoint or the signal-specific trace, metric, and log
+endpoints. If `otel.meta.exporter=meta` is selected without a valid endpoint, the agent disables
+Meta export and continues starting the application.
+
+`otel.meta.batch.export-timeout` remains accepted as a compatibility alias for
+`otel.meta.shutdown-timeout`. The new property takes precedence when both are configured. The
+timeout only bounds how long the shutdown hook waits; it cannot forcibly cancel a JVM HTTP call,
+so an in-flight export may finish later on the daemon worker.
+
+## Protocol
+
+The exporter sends versioned JSON batches to the configured URL using HTTP `POST`:
+
+```json
+{
+  "api_version": "v1",
+  "runtime_id": "7c066414-4c5a-4ba3-bc21-0d175d2019a1",
+  "seq_id": 1,
+  "tracer_time": 1787713200,
+  "resource": {
+    "service.name": "checkout",
+    "deployment.environment.name": "production",
+    "service.version": "1.4.0",
+    "telemetry.distro.version": "2.30.2",
+    "telemetry.sdk.language": "java",
+    "process.runtime.name": "OpenJDK Runtime Environment",
+    "process.runtime.version": "17.0.12+7",
+    "host.name": "checkout-6d9f8c7d8b-2xk9m",
+    "host.arch": "amd64",
+    "os.type": "linux",
+    "os.name": "Linux",
+    "os.description": "Ubuntu 24.04.2 LTS (Noble Numbat)",
+    "os.version": "6.11.0-26-generic",
+    "os.kernel.version": "#26~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC"
+  },
+  "events": [
+    {
+      "timestamp": 1787713200,
+      "request_type": "app-started",
+      "payload": {
+        "startup_status": "success"
+      }
+    }
+  ]
+}
+```
+
+`seq_id` starts at one for each `runtime_id` and increments once per HTTP request; retries reuse the
+same request and sequence. `tracer_time` is the request creation time in Unix seconds. An event
+`timestamp` is its observation time and has no independent sequence.
+
+Application, runtime, and host identity are consolidated into the OpenTelemetry `resource` object.
+Equivalent Datadog fields are not duplicated: for example, `service_name` maps to `service.name`,
+`tracer_version` to `telemetry.distro.version`, `hostname` to `host.name`, and `architecture` to
+`host.arch`. Values are sourced from the allowlisted OpenTelemetry resource where applicable and
+otherwise from JVM system properties, `/etc/os-release`, and `/proc/version` with safe fallbacks.
+
+Fields such as `class`, `name`, `create_time`, `last_update_time`, `date`, `date_ns`, and `time_us`
+are storage/index fields in a Datadog-style backend record, not agent protocol fields. A receiver
+can derive them from `runtime_id`, `tracer_time`, and `resource`. Event columns such as
+`app_started` and `app_dependencies_loaded` should likewise be derived from the structured `events`
+array instead of sending JSON strings inside JSON.
+
+The endpoint treats any `2xx` response as success. The exporter retries network failures, `408`,
+`429`, and `5xx` responses with bounded exponential backoff. It does not fall back to an OTLP
+endpoint or follow redirects automatically. Other `4xx` responses, serialization failures, and
+oversized requests are permanent failures and are not retried.
+
+Request JSON is written through a size-limited stream. With gzip enabled, both the uncompressed
+JSON and transmitted compressed body must fit `otel.exporter.meta.max-request-size`; the exporter
+does not allocate an unbounded intermediate JSON byte array.
+
+`app-started`, dependency, and integration events retain their latest value until a request is
+acknowledged successfully or fails permanently. After a retryable failure, the current value is
+retried with the next heartbeat, or sooner if a newer snapshot replaces it. A permanently failed
+value is discarded so that it cannot poison later heartbeat batches; a newer snapshot remains
+eligible for export. Only the latest dependency and integration snapshots are retained; stale full
+snapshots are not accumulated in the event queue.
+
+Each completed export writes one Java agent log record. Successful exports use `INFO`; final
+failures after retries use `WARNING`. Records include the sanitized endpoint, HTTP status,
+`seq_id`, event count, and attempt count. Request bodies, headers, URL user information, query
+parameters, and fragments are never logged. Detailed exception diagnostics are limited to `FINE`.
+
+The `/v1/meta` protocol is custom and is not an OTLP signal.
+
+## Events
+
+### `app-started`
+
+Emitted once after the Meta service starts. Its payload contains the installation method, startup
+status, and the enabled Meta capabilities. The agent version is reported as
+`resource.telemetry.distro.version` rather than duplicated in the event payload.
+
+### `app-dependencies-loaded`
+
+The agent observes the code source of application classes as the JVM defines them. Each distinct
+JAR location is resolved on a dedicated daemon thread; class transformation threads never open or
+hash JAR files. Maven `pom.properties` is preferred and produces a `groupId:artifactId` name and
+version. If Maven metadata is unavailable, manifest and file-name metadata is used with a SHA-1
+content identity. Spring Boot nested JAR locations and Maven metadata in exploded class directories
+are supported. Archive entry counts, Maven metadata sizes, dependency counts, and fallback hashing
+are bounded to protect the application process. At most 1,024 distinct locations and 1,024
+dependencies are retained; additional values are ignored with a warning.
+
+```json
+{
+  "request_type": "app-dependencies-loaded",
+  "payload": {
+    "dependencies": [
+      {
+        "name": "org.springframework:spring-webmvc",
+        "version": "6.2.1"
+      }
+    ]
+  }
+}
+```
+
+Dependencies are reported when a class is actually loaded from their code source. This is runtime
+discovery, not a static inventory of every file present on the class path. Locations and resolved
+dependencies are deduplicated for the lifetime of the process, and the Java agent's own JAR is
+excluded. Every event contains all dependencies discovered for the process at that point. A
+receiver should replace the previous dependency snapshot for the same `runtime_id`, not merge the
+arrays.
+
+### `app-integrations-change`
+
+Emitted after an instrumentation type matcher and Muzzle compatibility check select an application
+class and Byte Buddy reports that transformation as successful. It does not imply that the
+application has already executed the instrumented method or produced a span. The canonical module
+name is reported; configuration aliases are not emitted as separate integrations. Names are
+deduplicated across class loaders. Every event contains all integrations applied for the process at
+that point. A receiver should replace the previous integration snapshot for the same `runtime_id`,
+not merge the arrays.
+
+```json
+{
+  "request_type": "app-integrations-change",
+  "payload": {
+    "integrations": [
+      {
+        "name": "spring-webmvc",
+        "enabled": true
+      }
+    ]
+  }
+}
+```
+
+### `app-heartbeat`
+
+Emitted every 60 seconds by default to report that the process and Meta pipeline are alive. The
+event payload is empty because application, runtime, and host identity already exists in the
+request-level `resource` object. If other events are ready at the same time, the heartbeat can
+share their HTTP batch.
+
+```json
+{
+  "request_type": "app-heartbeat",
+  "payload": {}
+}
+```
+
+### `app-extended-heartbeat`
+
+Emitted every 24 hours by default. It carries complete current dependency and integration
+snapshots, including empty arrays when a collector has no data. This periodic full state lets a
+receiver reconstruct state after restarts or lost change-event requests without maintaining
+incremental agent-side updates.
+
+```json
+{
+  "request_type": "app-extended-heartbeat",
+  "payload": {
+    "configuration": [],
+    "dependencies": [
+      {
+        "name": "org.springframework:spring-webmvc",
+        "version": "6.2.1"
+      }
+    ],
+    "integrations": [
+      {
+        "name": "spring-webmvc",
+        "enabled": true
+      }
+    ]
+  }
+}
+```
+
+`configuration` is currently an empty reserved snapshot. Raw agent configuration is deliberately
+not copied because exporter headers and other settings can contain credentials. A future
+configuration collector must use an explicit safe allowlist before adding entries.
+
+If an extended heartbeat still has a retryable failure after the HTTP exporter's configured
+retries, its full state is sent again during the next ordinary heartbeat cycle. A successful or
+permanently failed extended-heartbeat request clears that retry state. The ordinary heartbeat
+continues on its normal interval regardless of export success or failure.
+
+Dependency and integration observations that occur during early agent installation are retained
+and exported after `app-started`. Under normal load, state changes are sent after
+`otel.meta.batch.schedule-delay`; JVM shutdown may trigger export earlier. Meta does not maintain a
+general event queue: one wake-up signal and only the latest value of each of the three state event
+types are retained. A request therefore contains at most those three state events plus the two
+scheduled heartbeat event types. The batching window only combines protocol events into HTTP
+requests; it does not change the full-snapshot semantics of dependency and integration payloads.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -46,6 +46,8 @@ import io.opentelemetry.javaagent.tooling.ignore.IgnoreAllow;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredClassLoadersMatcher;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesMatcher;
+import io.opentelemetry.javaagent.tooling.meta.MetaTelemetry;
+import io.opentelemetry.javaagent.tooling.meta.MetaTransformationListener;
 import io.opentelemetry.javaagent.tooling.muzzle.AgentTooling;
 import io.opentelemetry.javaagent.tooling.util.Trie;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
@@ -162,6 +164,9 @@ public class AgentInstaller {
     for (BeforeAgentListener agentListener :
         loadOrdered(BeforeAgentListener.class, extensionClassLoader)) {
       agentListener.beforeAgent(autoConfiguredSdk);
+    }
+    if (MetaTelemetry.isIntegrationCollectionEnabled()) {
+      agentBuilder = agentBuilder.with(new MetaTransformationListener());
     }
 
     agentBuilder = agentBuilder.with(new ClassLoadListener());

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -29,6 +29,7 @@ import io.opentelemetry.javaagent.tooling.field.VirtualFieldImplementationInstal
 import io.opentelemetry.javaagent.tooling.instrumentation.indy.ForwardIndyAdviceTransformer;
 import io.opentelemetry.javaagent.tooling.instrumentation.indy.IndyModuleRegistry;
 import io.opentelemetry.javaagent.tooling.instrumentation.indy.IndyTypeTransformerImpl;
+import io.opentelemetry.javaagent.tooling.meta.MetaTelemetry;
 import io.opentelemetry.javaagent.tooling.muzzle.AdviceInspector;
 import io.opentelemetry.javaagent.tooling.muzzle.HelperResourceBuilderImpl;
 import io.opentelemetry.javaagent.tooling.muzzle.InstrumentationModuleMuzzle;
@@ -209,6 +210,8 @@ public final class InstrumentationModuleInstaller {
       typeInstrumentation.transform(typeTransformer);
       extendableAgentBuilder = typeTransformer.getAgentBuilder();
       extendableAgentBuilder = contextProvider.injectFields(extendableAgentBuilder);
+      extendableAgentBuilder =
+          addMetaTransformationMarker(extendableAgentBuilder, instrumentationModule);
 
       agentBuilder = extendableAgentBuilder;
     }
@@ -278,11 +281,27 @@ public final class InstrumentationModuleInstaller {
       typeInstrumentation.transform(typeTransformer);
       extendableAgentBuilder = typeTransformer.getAgentBuilder();
       extendableAgentBuilder = contextProvider.injectFields(extendableAgentBuilder);
+      extendableAgentBuilder =
+          addMetaTransformationMarker(extendableAgentBuilder, instrumentationModule);
 
       agentBuilder = extendableAgentBuilder;
     }
 
     return agentBuilder;
+  }
+
+  private static AgentBuilder.Identified.Extendable addMetaTransformationMarker(
+      AgentBuilder.Identified.Extendable agentBuilder,
+      InstrumentationModule instrumentationModule) {
+    if (!MetaTelemetry.isIntegrationCollectionEnabled()) {
+      return agentBuilder;
+    }
+    return agentBuilder.transform(
+        (builder, typeDescription, classLoader, module, protectionDomain) -> {
+          MetaTelemetry.integrationMatched(
+              typeDescription.getName(), instrumentationModule.instrumentationName());
+          return builder;
+        });
   }
 
   private static AgentBuilder.Identified.Narrowable setTypeMatcher(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/HttpMetaExporter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/HttpMetaExporter.java
@@ -1,0 +1,456 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.opentelemetry.api.impl.InstrumentationUtil;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Logger;
+import java.util.zip.GZIPOutputStream;
+import javax.annotation.Nullable;
+
+final class HttpMetaExporter implements MetaExporter {
+
+  private static final Logger logger = Logger.getLogger(HttpMetaExporter.class.getName());
+  private static final long MAX_RETRY_DELAY_MILLIS = SECONDS.toMillis(10);
+  private static final int MAX_RESPONSE_BODY_BYTES = 64 * 1024;
+
+  private final URL endpoint;
+  private final Map<String, String> headers;
+  private final int timeoutMillis;
+  private final boolean gzipEnabled;
+  private final int maxRetries;
+  private final int maxRequestSizeBytes;
+  private final MetaJsonSerializer serializer;
+  private final Sleeper sleeper;
+
+  HttpMetaExporter(MetaConfiguration configuration) {
+    this(
+        configuration.getEndpoint(),
+        configuration.getHeaders(),
+        configuration.getTimeoutMillis(),
+        configuration.isGzipEnabled(),
+        configuration.getMaxRetries(),
+        configuration.getMaxRequestSizeBytes(),
+        new MetaJsonSerializer(),
+        Thread::sleep);
+  }
+
+  HttpMetaExporter(
+      URL endpoint,
+      Map<String, String> headers,
+      int timeoutMillis,
+      boolean gzipEnabled,
+      int maxRetries,
+      MetaJsonSerializer serializer,
+      Sleeper sleeper) {
+    this(
+        endpoint,
+        headers,
+        timeoutMillis,
+        gzipEnabled,
+        maxRetries,
+        Integer.MAX_VALUE,
+        serializer,
+        sleeper);
+  }
+
+  HttpMetaExporter(
+      URL endpoint,
+      Map<String, String> headers,
+      int timeoutMillis,
+      boolean gzipEnabled,
+      int maxRetries,
+      int maxRequestSizeBytes,
+      MetaJsonSerializer serializer,
+      Sleeper sleeper) {
+    this.endpoint = endpoint;
+    this.headers = headers;
+    this.timeoutMillis = timeoutMillis;
+    this.gzipEnabled = gzipEnabled;
+    this.maxRetries = maxRetries;
+    this.maxRequestSizeBytes = maxRequestSizeBytes;
+    this.serializer = serializer;
+    this.sleeper = sleeper;
+  }
+
+  @Override
+  public MetaExportResult export(MetaExportRequest request) {
+    MetaExportResult[] result = {MetaExportResult.PERMANENT_FAILURE};
+    try {
+      InstrumentationUtil.suppressInstrumentation(() -> result[0] = exportSuppressed(request));
+    } catch (RuntimeException e) {
+      logFailure(request, 0, 0, "unexpected_error");
+      logger.log(FINE, "Meta export failed unexpectedly", e);
+    }
+    return result[0];
+  }
+
+  private MetaExportResult exportSuppressed(MetaExportRequest request) {
+    RequestBody body;
+    try {
+      body = serializeRequest(request);
+    } catch (IOException e) {
+      RequestTooLargeException tooLarge = findRequestTooLarge(e);
+      if (tooLarge != null) {
+        logFailure(request, 0, 0, tooLarge.failureReason);
+      } else if (e instanceof JsonProcessingException) {
+        logFailure(request, 0, 0, "serialization_error");
+        logger.log(FINE, "Unable to serialize meta export request", e);
+      } else {
+        String failureReason = gzipEnabled ? "compression_error" : "serialization_error";
+        logFailure(request, 0, 0, failureReason);
+        logger.log(FINE, "Unable to create meta export request body", e);
+      }
+      return MetaExportResult.PERMANENT_FAILURE;
+    }
+
+    for (int attempt = 0; ; attempt++) {
+      AttemptResult attemptResult = send(body);
+      if (attemptResult.success) {
+        logSuccess(request, attemptResult.statusCode, attempt + 1);
+        return MetaExportResult.SUCCESS;
+      }
+      if (!attemptResult.retryable || attempt >= maxRetries) {
+        logFailure(request, attemptResult.statusCode, attempt + 1, attemptResult.failureReason);
+        return attemptResult.retryable
+            ? MetaExportResult.RETRYABLE_FAILURE
+            : MetaExportResult.PERMANENT_FAILURE;
+      }
+
+      long delayMillis =
+          attemptResult.retryAfterMillis > 0
+              ? attemptResult.retryAfterMillis
+              : retryDelayMillis(attempt);
+      try {
+        sleeper.sleep(Math.min(delayMillis, MAX_RETRY_DELAY_MILLIS));
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+        logFailure(request, attemptResult.statusCode, attempt + 1, "interrupted");
+        return MetaExportResult.RETRYABLE_FAILURE;
+      }
+    }
+  }
+
+  private RequestBody serializeRequest(MetaExportRequest request) throws IOException {
+    BoundedBuffer body =
+        new BoundedBuffer(
+            maxRequestSizeBytes,
+            gzipEnabled ? "compressed_request_too_large" : "request_too_large");
+    if (gzipEnabled) {
+      try (GZIPOutputStream gzipOutput = new GZIPOutputStream(body)) {
+        serializer.serialize(
+            request,
+            new SizeLimitingOutputStream(gzipOutput, maxRequestSizeBytes, "request_too_large"));
+      }
+    } else {
+      serializer.serialize(request, body);
+    }
+    return body.toRequestBody();
+  }
+
+  private AttemptResult send(RequestBody body) {
+    HttpURLConnection connection = null;
+    try {
+      connection = (HttpURLConnection) endpoint.openConnection();
+      connection.setRequestMethod("POST");
+      connection.setDoOutput(true);
+      connection.setUseCaches(false);
+      connection.setInstanceFollowRedirects(false);
+      connection.setConnectTimeout(timeoutMillis);
+      connection.setReadTimeout(timeoutMillis);
+      connection.setFixedLengthStreamingMode(body.length);
+      for (Map.Entry<String, String> header : headers.entrySet()) {
+        connection.setRequestProperty(header.getKey(), header.getValue());
+      }
+      connection.setRequestProperty("Content-Type", "application/json");
+      if (gzipEnabled) {
+        connection.setRequestProperty("Content-Encoding", "gzip");
+      }
+
+      try (OutputStream outputStream = connection.getOutputStream()) {
+        outputStream.write(body.bytes, 0, body.length);
+      }
+
+      int responseCode = connection.getResponseCode();
+      String retryAfter = connection.getHeaderField("Retry-After");
+      try {
+        drainResponse(connection, responseCode);
+      } catch (IOException e) {
+        logger.log(FINE, "Unable to drain meta export response for HTTP status {0}", responseCode);
+      }
+      if (responseCode >= 200 && responseCode < 300) {
+        return AttemptResult.success(responseCode);
+      }
+      boolean retryable =
+          responseCode == HttpURLConnection.HTTP_CLIENT_TIMEOUT
+              || responseCode == 429
+              || responseCode >= 500;
+      return AttemptResult.failure(
+          responseCode, retryable, parseRetryAfterMillis(retryAfter), "http_response");
+    } catch (IOException e) {
+      logger.log(FINE, "Meta export request failed with an I/O error: {0}", e.getClass().getName());
+      return AttemptResult.failure(-1, true, 0, e.getClass().getName());
+    } catch (RuntimeException e) {
+      logger.log(FINE, "Meta export request failed unexpectedly", e);
+      return AttemptResult.failure(-1, false, 0, e.getClass().getName());
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+
+  @Nullable
+  private static RequestTooLargeException findRequestTooLarge(IOException exception) {
+    Throwable current = exception;
+    while (current != null) {
+      if (current instanceof RequestTooLargeException) {
+        return (RequestTooLargeException) current;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+
+  private static void drainResponse(HttpURLConnection connection, int responseCode)
+      throws IOException {
+    InputStream stream =
+        responseCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+    if (stream == null) {
+      return;
+    }
+    try {
+      byte[] buffer = new byte[8192];
+      int totalBytes = 0;
+      int read;
+      while ((read = stream.read(buffer)) >= 0) {
+        // Drain the response so HttpURLConnection can reuse the connection.
+        totalBytes += read;
+        if (totalBytes >= MAX_RESPONSE_BODY_BYTES) {
+          break;
+        }
+      }
+    } finally {
+      stream.close();
+    }
+  }
+
+  private static long parseRetryAfterMillis(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return 0;
+    }
+    String trimmed = value.trim();
+    try {
+      return Math.max(0, SECONDS.toMillis(Long.parseLong(trimmed)));
+    } catch (NumberFormatException ignored) {
+      try {
+        long retryAtMillis =
+            ZonedDateTime.parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME)
+                .toInstant()
+                .toEpochMilli();
+        return Math.max(0, retryAtMillis - System.currentTimeMillis());
+      } catch (DateTimeParseException ignore) {
+        return 0;
+      }
+    }
+  }
+
+  private static long retryDelayMillis(int attempt) {
+    long baseDelay = Math.min(200L << Math.min(attempt, 5), MAX_RETRY_DELAY_MILLIS);
+    return ThreadLocalRandom.current().nextLong(baseDelay / 2, baseDelay + 1);
+  }
+
+  private void logSuccess(MetaExportRequest request, int statusCode, int attempts) {
+    logger.log(
+        INFO,
+        "Meta export succeeded: endpoint={0}, status_code={1}, seq_id={2}, event_count={3}, attempts={4}",
+        new Object[] {
+          endpointForLogging(),
+          statusCode,
+          request.getSequenceId(),
+          request.getEvents().size(),
+          attempts
+        });
+  }
+
+  private void logFailure(
+      MetaExportRequest request, int statusCode, int attempts, String failureReason) {
+    logger.log(
+        WARNING,
+        "Meta export failed: endpoint={0}, status_code={1}, seq_id={2}, event_count={3}, attempts={4}, reason={5}",
+        new Object[] {
+          endpointForLogging(),
+          statusCode > 0 ? statusCode : "unavailable",
+          request.getSequenceId(),
+          request.getEvents().size(),
+          attempts,
+          failureReason
+        });
+  }
+
+  private String endpointForLogging() {
+    StringBuilder value = new StringBuilder();
+    value.append(endpoint.getProtocol()).append("://").append(endpoint.getHost());
+    if (endpoint.getPort() >= 0) {
+      value.append(':').append(endpoint.getPort());
+    }
+    value.append(endpoint.getPath());
+    return value.toString();
+  }
+
+  interface Sleeper {
+    void sleep(long millis) throws InterruptedException;
+  }
+
+  private static final class AttemptResult {
+    private final boolean success;
+    private final int statusCode;
+    private final boolean retryable;
+    private final long retryAfterMillis;
+    private final String failureReason;
+
+    private static AttemptResult success(int statusCode) {
+      return new AttemptResult(true, statusCode, false, 0, "none");
+    }
+
+    private static AttemptResult failure(
+        int statusCode, boolean retryable, long retryAfterMillis, String failureReason) {
+      return new AttemptResult(false, statusCode, retryable, retryAfterMillis, failureReason);
+    }
+
+    private AttemptResult(
+        boolean success,
+        int statusCode,
+        boolean retryable,
+        long retryAfterMillis,
+        String failureReason) {
+      this.success = success;
+      this.statusCode = statusCode;
+      this.retryable = retryable;
+      this.retryAfterMillis = retryAfterMillis;
+      this.failureReason = failureReason;
+    }
+  }
+
+  private static final class RequestBody {
+    private final byte[] bytes;
+    private final int length;
+
+    private RequestBody(byte[] bytes, int length) {
+      this.bytes = bytes;
+      this.length = length;
+    }
+  }
+
+  private static final class BoundedBuffer extends OutputStream {
+    private static final int INITIAL_CAPACITY = 8 * 1024;
+
+    private final int maxBytes;
+    private final String failureReason;
+    private byte[] buffer;
+    private int count;
+
+    private BoundedBuffer(int maxBytes, String failureReason) {
+      this.maxBytes = maxBytes;
+      this.failureReason = failureReason;
+      this.buffer = new byte[Math.min(INITIAL_CAPACITY, maxBytes)];
+    }
+
+    @Override
+    public void write(int value) throws IOException {
+      ensureCapacity(1);
+      buffer[count++] = (byte) value;
+    }
+
+    @Override
+    public void write(byte[] value, int offset, int length) throws IOException {
+      if (offset < 0 || length < 0 || offset > value.length - length) {
+        throw new IndexOutOfBoundsException();
+      }
+      ensureCapacity(length);
+      System.arraycopy(value, offset, buffer, count, length);
+      count += length;
+    }
+
+    private void ensureCapacity(int additionalBytes) throws RequestTooLargeException {
+      if (additionalBytes > maxBytes - count) {
+        throw new RequestTooLargeException(failureReason);
+      }
+      int requiredCapacity = count + additionalBytes;
+      if (requiredCapacity <= buffer.length) {
+        return;
+      }
+      int doubledCapacity = buffer.length > maxBytes / 2 ? maxBytes : buffer.length * 2;
+      buffer = Arrays.copyOf(buffer, Math.max(requiredCapacity, doubledCapacity));
+    }
+
+    private RequestBody toRequestBody() {
+      return new RequestBody(buffer, count);
+    }
+  }
+
+  private static final class SizeLimitingOutputStream extends OutputStream {
+    private final OutputStream delegate;
+    private final int maxBytes;
+    private final String failureReason;
+    private int count;
+
+    private SizeLimitingOutputStream(OutputStream delegate, int maxBytes, String failureReason) {
+      this.delegate = delegate;
+      this.maxBytes = maxBytes;
+      this.failureReason = failureReason;
+    }
+
+    @Override
+    public void write(int value) throws IOException {
+      ensureCapacity(1);
+      delegate.write(value);
+      count++;
+    }
+
+    @Override
+    public void write(byte[] value, int offset, int length) throws IOException {
+      if (length > maxBytes - count) {
+        throw new RequestTooLargeException(failureReason);
+      }
+      delegate.write(value, offset, length);
+      count += length;
+    }
+
+    private void ensureCapacity(int additionalBytes) throws RequestTooLargeException {
+      if (additionalBytes > maxBytes - count) {
+        throw new RequestTooLargeException(failureReason);
+      }
+    }
+  }
+
+  private static final class RequestTooLargeException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    private final String failureReason;
+
+    private RequestTooLargeException(String failureReason) {
+      super(failureReason);
+      this.failureReason = failureReason;
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaConfiguration.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaConfiguration.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+final class MetaConfiguration {
+
+  private static final String META_EXPORTER = "otel.meta.exporter";
+  private static final String ENDPOINT = "otel.exporter.meta.endpoint";
+  private static final String HEADERS = "otel.exporter.meta.headers";
+  private static final String TIMEOUT = "otel.exporter.meta.timeout";
+  private static final String COMPRESSION = "otel.exporter.meta.compression";
+  private static final String MAX_RETRIES = "otel.exporter.meta.max-retries";
+  private static final String MAX_REQUEST_SIZE = "otel.exporter.meta.max-request-size";
+  private static final String SCHEDULE_DELAY = "otel.meta.batch.schedule-delay";
+  private static final String SHUTDOWN_TIMEOUT = "otel.meta.shutdown-timeout";
+  private static final String LEGACY_EXPORT_TIMEOUT = "otel.meta.batch.export-timeout";
+  private static final String HEARTBEAT_INTERVAL = "otel.meta.heartbeat.interval";
+  private static final String EXTENDED_HEARTBEAT_INTERVAL = "otel.meta.extended-heartbeat.interval";
+  private static final String APP_STARTED_ENABLED = "otel.meta.app-started.enabled";
+  private static final String APP_DEPENDENCIES_LOADED_ENABLED =
+      "otel.meta.app-dependencies-loaded.enabled";
+  private static final String APP_INTEGRATIONS_CHANGE_ENABLED =
+      "otel.meta.app-integrations-change.enabled";
+
+  private static final int DEFAULT_TIMEOUT_MILLIS = 10_000;
+  private static final int DEFAULT_MAX_RETRIES = 3;
+  private static final int DEFAULT_MAX_REQUEST_SIZE_BYTES = 5 * 1024 * 1024;
+  private static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 1_000;
+  private static final long DEFAULT_SHUTDOWN_TIMEOUT_MILLIS = 10_000;
+  private static final long DEFAULT_HEARTBEAT_INTERVAL_MILLIS = 60_000;
+  private static final long DEFAULT_EXTENDED_HEARTBEAT_INTERVAL_MILLIS = 86_400_000;
+  private static final Set<String> RESERVED_HEADERS =
+      new HashSet<>(
+          asList(
+              "connection",
+              "content-encoding",
+              "content-length",
+              "content-type",
+              "host",
+              "transfer-encoding"));
+
+  private final boolean enabled;
+  @Nullable private final URL endpoint;
+  private final Map<String, String> headers;
+  private final int timeoutMillis;
+  private final boolean gzipEnabled;
+  private final int maxRetries;
+  private final int maxRequestSizeBytes;
+  private final long scheduleDelayMillis;
+  private final long shutdownTimeoutMillis;
+  private final long heartbeatIntervalMillis;
+  private final long extendedHeartbeatIntervalMillis;
+  private final boolean appStartedEnabled;
+  private final boolean appDependenciesLoadedEnabled;
+  private final boolean appIntegrationsChangeEnabled;
+
+  static MetaConfiguration create(ConfigProperties config) {
+    String exporter = normalize(config.getString(META_EXPORTER), "none");
+    if ("none".equals(exporter)) {
+      return disabled();
+    }
+    if (!"meta".equals(exporter)) {
+      throw new IllegalArgumentException(
+          "Unsupported value for " + META_EXPORTER + ": " + exporter);
+    }
+
+    URL endpoint = parseEndpoint(config.getString(ENDPOINT));
+    int timeoutMillis = positive(config.getLong(TIMEOUT), DEFAULT_TIMEOUT_MILLIS, TIMEOUT);
+    String compression = normalize(config.getString(COMPRESSION), "none");
+    if (!"none".equals(compression) && !"gzip".equals(compression)) {
+      throw new IllegalArgumentException(
+          "Unsupported value for " + COMPRESSION + ": " + compression);
+    }
+    int maxRetries = nonNegative(config.getInt(MAX_RETRIES), DEFAULT_MAX_RETRIES, MAX_RETRIES);
+    int maxRequestSizeBytes =
+        positive(
+            config.getLong(MAX_REQUEST_SIZE), DEFAULT_MAX_REQUEST_SIZE_BYTES, MAX_REQUEST_SIZE);
+    long scheduleDelayMillis =
+        positive(config.getLong(SCHEDULE_DELAY), DEFAULT_SCHEDULE_DELAY_MILLIS, SCHEDULE_DELAY);
+    Long configuredShutdownTimeout = config.getLong(SHUTDOWN_TIMEOUT);
+    String shutdownTimeoutProperty = SHUTDOWN_TIMEOUT;
+    if (configuredShutdownTimeout == null) {
+      configuredShutdownTimeout = config.getLong(LEGACY_EXPORT_TIMEOUT);
+      if (configuredShutdownTimeout != null) {
+        shutdownTimeoutProperty = LEGACY_EXPORT_TIMEOUT;
+      }
+    }
+    long shutdownTimeoutMillis =
+        positive(
+            configuredShutdownTimeout, DEFAULT_SHUTDOWN_TIMEOUT_MILLIS, shutdownTimeoutProperty);
+    long heartbeatIntervalMillis =
+        positive(
+            config.getLong(HEARTBEAT_INTERVAL),
+            DEFAULT_HEARTBEAT_INTERVAL_MILLIS,
+            HEARTBEAT_INTERVAL);
+    long extendedHeartbeatIntervalMillis =
+        positive(
+            config.getLong(EXTENDED_HEARTBEAT_INTERVAL),
+            DEFAULT_EXTENDED_HEARTBEAT_INTERVAL_MILLIS,
+            EXTENDED_HEARTBEAT_INTERVAL);
+
+    return new MetaConfiguration(
+        true,
+        endpoint,
+        sanitizeHeaders(config.getMap(HEADERS)),
+        timeoutMillis,
+        "gzip".equals(compression),
+        maxRetries,
+        maxRequestSizeBytes,
+        scheduleDelayMillis,
+        shutdownTimeoutMillis,
+        heartbeatIntervalMillis,
+        extendedHeartbeatIntervalMillis,
+        defaultBoolean(config.getBoolean(APP_STARTED_ENABLED), true),
+        defaultBoolean(config.getBoolean(APP_DEPENDENCIES_LOADED_ENABLED), true),
+        defaultBoolean(config.getBoolean(APP_INTEGRATIONS_CHANGE_ENABLED), true));
+  }
+
+  private static MetaConfiguration disabled() {
+    return new MetaConfiguration(
+        false,
+        null,
+        emptyMap(),
+        DEFAULT_TIMEOUT_MILLIS,
+        false,
+        DEFAULT_MAX_RETRIES,
+        DEFAULT_MAX_REQUEST_SIZE_BYTES,
+        DEFAULT_SCHEDULE_DELAY_MILLIS,
+        DEFAULT_SHUTDOWN_TIMEOUT_MILLIS,
+        DEFAULT_HEARTBEAT_INTERVAL_MILLIS,
+        DEFAULT_EXTENDED_HEARTBEAT_INTERVAL_MILLIS,
+        true,
+        true,
+        true);
+  }
+
+  private MetaConfiguration(
+      boolean enabled,
+      @Nullable URL endpoint,
+      Map<String, String> headers,
+      int timeoutMillis,
+      boolean gzipEnabled,
+      int maxRetries,
+      int maxRequestSizeBytes,
+      long scheduleDelayMillis,
+      long shutdownTimeoutMillis,
+      long heartbeatIntervalMillis,
+      long extendedHeartbeatIntervalMillis,
+      boolean appStartedEnabled,
+      boolean appDependenciesLoadedEnabled,
+      boolean appIntegrationsChangeEnabled) {
+    this.enabled = enabled;
+    this.endpoint = endpoint;
+    this.headers = headers;
+    this.timeoutMillis = timeoutMillis;
+    this.gzipEnabled = gzipEnabled;
+    this.maxRetries = maxRetries;
+    this.maxRequestSizeBytes = maxRequestSizeBytes;
+    this.scheduleDelayMillis = scheduleDelayMillis;
+    this.shutdownTimeoutMillis = shutdownTimeoutMillis;
+    this.heartbeatIntervalMillis = heartbeatIntervalMillis;
+    this.extendedHeartbeatIntervalMillis = extendedHeartbeatIntervalMillis;
+    this.appStartedEnabled = appStartedEnabled;
+    this.appDependenciesLoadedEnabled = appDependenciesLoadedEnabled;
+    this.appIntegrationsChangeEnabled = appIntegrationsChangeEnabled;
+  }
+
+  boolean isEnabled() {
+    return enabled;
+  }
+
+  URL getEndpoint() {
+    if (endpoint == null) {
+      throw new IllegalStateException("Meta endpoint is unavailable when the exporter is disabled");
+    }
+    return endpoint;
+  }
+
+  Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  int getTimeoutMillis() {
+    return timeoutMillis;
+  }
+
+  boolean isGzipEnabled() {
+    return gzipEnabled;
+  }
+
+  int getMaxRetries() {
+    return maxRetries;
+  }
+
+  int getMaxRequestSizeBytes() {
+    return maxRequestSizeBytes;
+  }
+
+  long getScheduleDelayMillis() {
+    return scheduleDelayMillis;
+  }
+
+  long getShutdownTimeoutMillis() {
+    return shutdownTimeoutMillis;
+  }
+
+  long getHeartbeatIntervalMillis() {
+    return heartbeatIntervalMillis;
+  }
+
+  long getExtendedHeartbeatIntervalMillis() {
+    return extendedHeartbeatIntervalMillis;
+  }
+
+  boolean isAppStartedEnabled() {
+    return appStartedEnabled;
+  }
+
+  boolean isAppDependenciesLoadedEnabled() {
+    return appDependenciesLoadedEnabled;
+  }
+
+  boolean isAppIntegrationsChangeEnabled() {
+    return appIntegrationsChangeEnabled;
+  }
+
+  private static URL parseEndpoint(@Nullable String value) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(
+          ENDPOINT + " must be configured when " + META_EXPORTER + " is meta");
+    }
+    try {
+      URL endpoint = new URL(value.trim());
+      String protocol = endpoint.getProtocol();
+      if (!"http".equalsIgnoreCase(protocol) && !"https".equalsIgnoreCase(protocol)) {
+        throw new IllegalArgumentException(ENDPOINT + " must use http or https");
+      }
+      if (endpoint.getHost().isEmpty()) {
+        throw new IllegalArgumentException(ENDPOINT + " must include a host");
+      }
+      if (endpoint.getUserInfo() != null) {
+        throw new IllegalArgumentException(ENDPOINT + " must not include user info");
+      }
+      if (endpoint.getRef() != null) {
+        throw new IllegalArgumentException(ENDPOINT + " must not include a fragment");
+      }
+      return endpoint;
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException("Invalid " + ENDPOINT, e);
+    }
+  }
+
+  private static Map<String, String> sanitizeHeaders(Map<String, String> headers) {
+    if (headers.isEmpty()) {
+      return emptyMap();
+    }
+    Map<String, String> sanitized = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      String name = decodeHeader(entry.getKey());
+      String value = decodeHeader(entry.getValue());
+      if (name == null || value == null) {
+        throw new IllegalArgumentException(HEADERS + " must not contain null names or values");
+      }
+      name = name.trim();
+      if (!isValidHeaderName(name)) {
+        throw new IllegalArgumentException("Invalid HTTP header name in " + HEADERS + ": " + name);
+      }
+      if (RESERVED_HEADERS.contains(name.toLowerCase(Locale.ROOT))) {
+        throw new IllegalArgumentException(HEADERS + " must not override reserved header " + name);
+      }
+      if (!isValidHeaderValue(value)) {
+        throw new IllegalArgumentException(
+            "Invalid HTTP header value in " + HEADERS + " for " + name);
+      }
+      sanitized.put(name, value);
+    }
+    return unmodifiableMap(sanitized);
+  }
+
+  private static boolean isValidHeaderName(String value) {
+    if (value.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char character = value.charAt(i);
+      if ((character >= 'a' && character <= 'z')
+          || (character >= 'A' && character <= 'Z')
+          || (character >= '0' && character <= '9')) {
+        continue;
+      }
+      if ("!#$%&'*+-.^_`|~".indexOf(character) < 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isValidHeaderValue(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      char character = value.charAt(i);
+      if ((character < 0x20 && character != '\t') || character == 0x7f) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Nullable
+  private static String decodeHeader(@Nullable String value) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      return URLDecoder.decode(value, UTF_8.name());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid URL encoding in " + HEADERS, e);
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static String normalize(@Nullable String value, String defaultValue) {
+    return value == null || value.trim().isEmpty()
+        ? defaultValue
+        : value.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private static boolean defaultBoolean(@Nullable Boolean value, boolean defaultValue) {
+    return value != null ? value : defaultValue;
+  }
+
+  private static int positive(@Nullable Long value, int defaultValue, String propertyName) {
+    long resolved = value != null ? value : defaultValue;
+    if (resolved <= 0 || resolved > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          propertyName + " must be between 1 and " + Integer.MAX_VALUE);
+    }
+    return (int) resolved;
+  }
+
+  private static long positive(@Nullable Long value, long defaultValue, String propertyName) {
+    long resolved = value != null ? value : defaultValue;
+    if (resolved <= 0) {
+      throw new IllegalArgumentException(propertyName + " must be positive");
+    }
+    return resolved;
+  }
+
+  private static int nonNegative(@Nullable Integer value, int defaultValue, String propertyName) {
+    int resolved = value != null ? value : defaultValue;
+    if (resolved < 0) {
+      throw new IllegalArgumentException(propertyName + " must not be negative");
+    }
+    return resolved;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaDependency.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaDependency.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+final class MetaDependency {
+
+  private final String name;
+  private final String version;
+  @Nullable private final String hash;
+
+  MetaDependency(String name, String version, @Nullable String hash) {
+    this.name = name;
+    this.version = version;
+    this.hash = hash;
+  }
+
+  String key() {
+    return name + '\u0000' + version + '\u0000' + (hash == null ? "" : hash);
+  }
+
+  Map<String, Object> toPayload() {
+    Map<String, Object> dependency = new LinkedHashMap<>();
+    dependency.put("name", name);
+    if (!version.isEmpty()) {
+      dependency.put("version", version);
+    }
+    if (hash != null) {
+      dependency.put("hash", hash);
+    }
+    return dependency;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaDependencyCollector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaDependencyCollector.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+
+import io.opentelemetry.javaagent.bootstrap.AgentClassLoader;
+import io.opentelemetry.javaagent.tooling.ExtensionClassLoader;
+import io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader;
+import java.lang.instrument.ClassFileTransformer;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+final class MetaDependencyCollector implements ClassFileTransformer, AutoCloseable {
+
+  private static final Logger logger = Logger.getLogger(MetaDependencyCollector.class.getName());
+  private static final int MAX_LOCATIONS = 1_024;
+  private static final int MAX_DEPENDENCIES = 1_024;
+  private static final int MAX_RESOLVE_BATCH_SIZE = 32;
+  private static final long POLL_DELAY_MILLIS = 200;
+
+  private final BlockingQueue<URL> locations;
+  private final Set<String> seenLocations = ConcurrentHashMap.newKeySet();
+  // Only accessed by the resolver worker. Retaining payloads lets every event carry a full
+  // snapshot, so receivers can replace state instead of merging increments.
+  private final Map<String, Map<String, Object>> dependencies = new LinkedHashMap<>();
+  private final AtomicBoolean running = new AtomicBoolean();
+  private final AtomicBoolean limitWarningLogged = new AtomicBoolean();
+  private final AtomicBoolean dependencyLimitWarningLogged = new AtomicBoolean();
+  private final Thread worker = new Thread(this::runWorker, "opentelemetry-meta-dependencies");
+  private final int maxLocations;
+  private final int maxDependencies;
+  @Nullable private final String agentLocation;
+
+  private volatile List<Map<String, Object>> currentDependencies = emptyList();
+
+  @Nullable private volatile MetaService service;
+
+  MetaDependencyCollector() {
+    this(codeSourceLocation(MetaDependencyCollector.class), MAX_LOCATIONS, MAX_DEPENDENCIES);
+  }
+
+  MetaDependencyCollector(@Nullable URL agentLocation) {
+    this(agentLocation, MAX_LOCATIONS, MAX_DEPENDENCIES);
+  }
+
+  MetaDependencyCollector(@Nullable URL agentLocation, int maxLocations, int maxDependencies) {
+    this.locations = new ArrayBlockingQueue<>(maxLocations);
+    this.maxLocations = maxLocations;
+    this.maxDependencies = maxDependencies;
+    this.agentLocation = agentLocation == null ? null : enclosingJar(agentLocation);
+    worker.setDaemon(true);
+    worker.setContextClassLoader(null);
+  }
+
+  @Override
+  @Nullable
+  public byte[] transform(
+      ClassLoader loader,
+      String className,
+      @Nullable Class<?> classBeingRedefined,
+      @Nullable ProtectionDomain protectionDomain,
+      byte[] classfileBuffer) {
+    if (shouldIgnore(loader, className) || protectionDomain == null) {
+      return null;
+    }
+    CodeSource codeSource = protectionDomain.getCodeSource();
+    if (codeSource != null) {
+      recordLocation(codeSource.getLocation());
+    }
+    return null;
+  }
+
+  private static boolean shouldIgnore(ClassLoader loader, String className) {
+    return loader == null
+        || loader instanceof AgentClassLoader
+        || loader instanceof ExtensionClassLoader
+        || loader instanceof InstrumentationModuleClassLoader
+        || className == null
+        || className.startsWith("io/opentelemetry/javaagent/");
+  }
+
+  void recordLocation(@Nullable URL location) {
+    if (location == null) {
+      return;
+    }
+    String key = location.toExternalForm();
+    if (enclosingJar(location).equals(agentLocation)) {
+      return;
+    }
+    if (seenLocations.contains(key)) {
+      return;
+    }
+    if (seenLocations.size() >= maxLocations) {
+      if (limitWarningLogged.compareAndSet(false, true)) {
+        logger.log(
+            WARNING,
+            "Meta dependency location limit of {0} was reached; additional locations are ignored",
+            maxLocations);
+      }
+    } else if (seenLocations.add(key) && !locations.offer(location)) {
+      seenLocations.remove(key);
+      if (limitWarningLogged.compareAndSet(false, true)) {
+        logger.warning("Meta dependency location queue is full; a location was dropped");
+      }
+    }
+  }
+
+  @Nullable
+  private static URL codeSourceLocation(Class<?> type) {
+    ProtectionDomain protectionDomain = type.getProtectionDomain();
+    if (protectionDomain == null) {
+      return null;
+    }
+    CodeSource codeSource = protectionDomain.getCodeSource();
+    return codeSource == null ? null : codeSource.getLocation();
+  }
+
+  private static String enclosingJar(URL location) {
+    String value = location.toExternalForm();
+    if (value.startsWith("jar:")) {
+      value = value.substring("jar:".length());
+    }
+    int nestedSeparator = value.indexOf("!/");
+    return nestedSeparator < 0 ? value : value.substring(0, nestedSeparator);
+  }
+
+  void start(MetaService service) {
+    this.service = service;
+    if (running.compareAndSet(false, true)) {
+      worker.start();
+    }
+  }
+
+  private void runWorker() {
+    while (running.get() || !locations.isEmpty()) {
+      URL first;
+      try {
+        first = locations.poll(POLL_DELAY_MILLIS, MILLISECONDS);
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      if (first == null) {
+        continue;
+      }
+
+      List<URL> batch = new ArrayList<>(MAX_RESOLVE_BATCH_SIZE);
+      batch.add(first);
+      locations.drainTo(batch, MAX_RESOLVE_BATCH_SIZE - 1);
+      boolean changed = false;
+      for (URL location : batch) {
+        try {
+          for (MetaDependency dependency : MetaDependencyResolver.resolve(location)) {
+            if (dependencies.containsKey(dependency.key())) {
+              continue;
+            }
+            if (dependencies.size() >= maxDependencies) {
+              if (dependencyLimitWarningLogged.compareAndSet(false, true)) {
+                logger.log(
+                    WARNING,
+                    "Meta dependency limit of {0} was reached; additional dependencies are ignored",
+                    maxDependencies);
+              }
+              break;
+            } else {
+              dependencies.put(dependency.key(), dependency.toPayload());
+              changed = true;
+            }
+          }
+        } catch (RuntimeException e) {
+          logger.log(FINE, "Unable to collect Meta dependency from " + location, e);
+        }
+      }
+      if (!changed) {
+        continue;
+      }
+      List<Map<String, Object>> snapshot =
+          Collections.unmodifiableList(new ArrayList<>(dependencies.values()));
+      currentDependencies = snapshot;
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("dependencies", snapshot);
+      MetaService currentService = service;
+      if (currentService != null) {
+        currentService.emit("app-dependencies-loaded", payload);
+      }
+    }
+  }
+
+  List<Map<String, Object>> snapshot() {
+    return currentDependencies;
+  }
+
+  @Override
+  @SuppressWarnings("Interruption") // Cancels this collector's owned daemon after graceful timeout.
+  public void close() {
+    if (!running.compareAndSet(true, false)) {
+      return;
+    }
+    try {
+      worker.join(5_000);
+      if (worker.isAlive()) {
+        worker.interrupt();
+        logger.warning("Timed out waiting for the Meta dependency collector to stop");
+      }
+    } catch (InterruptedException ignored) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaDependencyResolver.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaDependencyResolver.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.logging.Level.FINE;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import javax.annotation.Nullable;
+
+final class MetaDependencyResolver {
+
+  private static final int MAX_ARCHIVE_ENTRIES = 100_000;
+  private static final int MAX_POM_PROPERTIES = 256;
+  private static final int MAX_POM_PROPERTIES_BYTES = 64 * 1024;
+  private static final int MAX_MANIFEST_BYTES = 1024 * 1024;
+  private static final long MAX_HASH_BYTES = 256L * 1024 * 1024;
+  private static final int MAX_METADATA_VALUE_LENGTH = 256;
+
+  private static final Logger logger = Logger.getLogger(MetaDependencyResolver.class.getName());
+  private static final Pattern JAR_FILE_PATTERN =
+      Pattern.compile("^(.+?)(?:-([0-9][^-]+(?:-\\w+)?))?\\.jar$");
+  private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+  static List<MetaDependency> resolve(URL location) {
+    try {
+      JarMetadata metadata = read(location);
+      if (metadata == null) {
+        return emptyList();
+      }
+      List<MetaDependency> dependencies = fromPomProperties(metadata.pomProperties);
+      if (!dependencies.isEmpty()) {
+        return dependencies;
+      }
+      return singletonList(fromManifestAndFileName(metadata));
+    } catch (IOException | RuntimeException | URISyntaxException e) {
+      logger.log(FINE, "Unable to resolve Meta dependency from " + location, e);
+      return emptyList();
+    }
+  }
+
+  @Nullable
+  private static JarMetadata read(URL location) throws IOException, URISyntaxException {
+    if ("file".equals(location.getProtocol())) {
+      File file = new File(location.toURI());
+      if (file.isFile()) {
+        return readJarFile(file);
+      }
+      return file.isDirectory() ? readExplodedDirectory(file) : null;
+    }
+    if (!"jar".equals(location.getProtocol())) {
+      return null;
+    }
+    return readJarLocation(location.toExternalForm().substring("jar:".length()));
+  }
+
+  @Nullable
+  private static JarMetadata readJarLocation(String value) throws IOException, URISyntaxException {
+    String path = stripJarSuffix(value);
+    if (path.startsWith("file:")) {
+      int nestedSeparator = path.indexOf("!/");
+      if (nestedSeparator < 0) {
+        return readJarFile(new File(new URI(path)));
+      }
+      File outerJar = new File(new URI(path.substring(0, nestedSeparator)));
+      String innerJar = path.substring(nestedSeparator + 2);
+      return readNestedJar(outerJar, innerJar);
+    }
+    if (path.startsWith("nested:")) {
+      path = path.substring("nested:".length());
+      int nestedSeparator = path.indexOf("/!");
+      if (nestedSeparator < 0) {
+        return null;
+      }
+      File outerJar = fileFromPath(path.substring(0, nestedSeparator));
+      String innerJar = path.substring(nestedSeparator + 2);
+      return readNestedJar(outerJar, innerJar);
+    }
+    return null;
+  }
+
+  private static String stripJarSuffix(String value) {
+    if (value.endsWith("!/")) {
+      return value.substring(0, value.length() - 2);
+    }
+    if (value.endsWith("!")) {
+      return value.substring(0, value.length() - 1);
+    }
+    return value;
+  }
+
+  private static File fileFromPath(String path) throws URISyntaxException {
+    return new File(new URI("file", null, path, null));
+  }
+
+  private static JarMetadata readJarFile(File file) throws IOException {
+    try (JarFile jarFile = new JarFile(file, false)) {
+      Map<String, Properties> pomProperties = new LinkedHashMap<>();
+      Enumeration<JarEntry> entries = jarFile.entries();
+      int entryCount = 0;
+      while (entries.hasMoreElements()) {
+        ensureNotInterrupted();
+        JarEntry entry = entries.nextElement();
+        if (++entryCount > MAX_ARCHIVE_ENTRIES) {
+          throw new IOException("JAR contains too many entries");
+        }
+        if (isPomProperties(entry)) {
+          if (pomProperties.size() >= MAX_POM_PROPERTIES) {
+            throw new IOException("JAR contains too many pom.properties entries");
+          }
+          try (InputStream inputStream = jarFile.getInputStream(entry)) {
+            pomProperties.put(entry.getName(), readProperties(inputStream));
+          }
+        }
+      }
+      Attributes manifestAttributes = new Attributes();
+      JarEntry manifestEntry = jarFile.getJarEntry("META-INF/MANIFEST.MF");
+      if (manifestEntry != null) {
+        try (InputStream inputStream = jarFile.getInputStream(manifestEntry)) {
+          manifestAttributes = readManifest(inputStream).getMainAttributes();
+        }
+      }
+      return new JarMetadata(
+          file.getName(), pomProperties, manifestAttributes, () -> new FileInputStream(file));
+    }
+  }
+
+  @Nullable
+  private static JarMetadata readExplodedDirectory(File root) throws IOException {
+    File mavenDirectory = new File(root, "META-INF/maven");
+    File[] groupDirectories = mavenDirectory.listFiles(File::isDirectory);
+    if (groupDirectories == null) {
+      return null;
+    }
+
+    Map<String, Properties> pomProperties = new LinkedHashMap<>();
+    int visitedDirectories = 0;
+    for (File groupDirectory : groupDirectories) {
+      ensureNotInterrupted();
+      if (++visitedDirectories > MAX_ARCHIVE_ENTRIES) {
+        throw new IOException("Exploded application contains too many Maven metadata directories");
+      }
+      File[] artifactDirectories = groupDirectory.listFiles(File::isDirectory);
+      if (artifactDirectories == null) {
+        continue;
+      }
+      for (File artifactDirectory : artifactDirectories) {
+        ensureNotInterrupted();
+        if (++visitedDirectories > MAX_ARCHIVE_ENTRIES) {
+          throw new IOException(
+              "Exploded application contains too many Maven metadata directories");
+        }
+        File propertiesFile = new File(artifactDirectory, "pom.properties");
+        if (!propertiesFile.isFile()) {
+          continue;
+        }
+        if (pomProperties.size() >= MAX_POM_PROPERTIES) {
+          throw new IOException("Exploded application contains too many pom.properties entries");
+        }
+        try (InputStream inputStream = new FileInputStream(propertiesFile)) {
+          String relativeName = root.toURI().relativize(propertiesFile.toURI()).getPath();
+          pomProperties.put(relativeName, readProperties(inputStream));
+        }
+      }
+    }
+    if (pomProperties.isEmpty()) {
+      return null;
+    }
+    return new JarMetadata(
+        root.getName(),
+        pomProperties,
+        new Attributes(),
+        () -> new ByteArrayInputStream(new byte[0]));
+  }
+
+  @Nullable
+  private static JarMetadata readNestedJar(File outerJar, String innerJar) throws IOException {
+    try (JarFile jarFile = new JarFile(outerJar, false)) {
+      JarEntry nestedEntry = jarFile.getJarEntry(innerJar);
+      if (nestedEntry == null || nestedEntry.isDirectory()) {
+        return null;
+      }
+      try (InputStream inputStream = jarFile.getInputStream(nestedEntry);
+          ZipInputStream nestedInputStream = new ZipInputStream(inputStream)) {
+        Map<String, Properties> pomProperties = new LinkedHashMap<>();
+        Attributes manifestAttributes = new Attributes();
+        ZipEntry entry;
+        int entryCount = 0;
+        while ((entry = nestedInputStream.getNextEntry()) != null) {
+          ensureNotInterrupted();
+          if (++entryCount > MAX_ARCHIVE_ENTRIES) {
+            throw new IOException("Nested JAR contains too many entries");
+          }
+          if (isPomProperties(entry)) {
+            if (pomProperties.size() >= MAX_POM_PROPERTIES) {
+              throw new IOException("Nested JAR contains too many pom.properties entries");
+            }
+            pomProperties.put(entry.getName(), readProperties(nestedInputStream));
+          } else if ("META-INF/MANIFEST.MF".equalsIgnoreCase(entry.getName())) {
+            manifestAttributes = readManifest(nestedInputStream).getMainAttributes();
+          }
+        }
+        return new JarMetadata(
+            new File(innerJar).getName(),
+            pomProperties,
+            manifestAttributes,
+            () -> new NestedJarInputStream(outerJar, innerJar));
+      }
+    }
+  }
+
+  private static boolean isPomProperties(ZipEntry entry) {
+    return !entry.isDirectory()
+        && entry.getName().startsWith("META-INF/maven/")
+        && entry.getName().endsWith("/pom.properties");
+  }
+
+  private static Properties readProperties(InputStream inputStream) throws IOException {
+    byte[] content = readBounded(inputStream, MAX_POM_PROPERTIES_BYTES, "pom.properties");
+    Properties properties = new Properties();
+    properties.load(new ByteArrayInputStream(content));
+    return properties;
+  }
+
+  private static Manifest readManifest(InputStream inputStream) throws IOException {
+    return new Manifest(
+        new ByteArrayInputStream(readBounded(inputStream, MAX_MANIFEST_BYTES, "JAR manifest")));
+  }
+
+  private static byte[] readBounded(InputStream inputStream, int maxBytes, String description)
+      throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[4_096];
+    int totalBytes = 0;
+    int read;
+    while ((read = inputStream.read(buffer)) >= 0) {
+      ensureNotInterrupted();
+      totalBytes += read;
+      if (totalBytes > maxBytes) {
+        throw new IOException(description + " is too large");
+      }
+      outputStream.write(buffer, 0, read);
+    }
+    return outputStream.toByteArray();
+  }
+
+  private static void ensureNotInterrupted() throws IOException {
+    if (Thread.currentThread().isInterrupted()) {
+      throw new IOException("Meta dependency resolution was interrupted");
+    }
+  }
+
+  private static List<MetaDependency> fromPomProperties(Map<String, Properties> pomProperties) {
+    Map<String, MetaDependency> dependencies = new LinkedHashMap<>();
+    for (Properties properties : pomProperties.values()) {
+      String groupId = metadataValue(properties.getProperty("groupId"));
+      String artifactId = metadataValue(properties.getProperty("artifactId"));
+      String version = metadataValue(properties.getProperty("version"));
+      if (groupId.isEmpty() || artifactId.isEmpty() || version.isEmpty()) {
+        continue;
+      }
+      MetaDependency dependency = new MetaDependency(groupId + ":" + artifactId, version, null);
+      dependencies.put(dependency.key(), dependency);
+    }
+    return new ArrayList<>(dependencies.values());
+  }
+
+  private static MetaDependency fromManifestAndFileName(JarMetadata metadata) {
+    Matcher matcher = JAR_FILE_PATTERN.matcher(metadata.jarName);
+    String fileName = metadata.jarName;
+    String artifactName =
+        fileName.endsWith(".jar")
+            ? fileName.substring(0, fileName.length() - ".jar".length())
+            : fileName;
+    String fileVersion = "";
+    if (matcher.matches()) {
+      artifactName = matcher.group(1);
+      fileVersion = trim(matcher.group(2));
+    }
+
+    String bundleSymbolicName = manifestValue(metadata.attributes, "Bundle-SymbolicName");
+    String bundleName = manifestValue(metadata.attributes, "Bundle-Name");
+    String implementationTitle = manifestValue(metadata.attributes, "Implementation-Title");
+    String bundleVersion = manifestValue(metadata.attributes, "Bundle-Version");
+    String implementationVersion = manifestValue(metadata.attributes, "Implementation-Version");
+
+    String name;
+    if (isValidArtifactId(bundleName)) {
+      name = bundleName;
+    } else if (isValidArtifactId(implementationTitle)) {
+      name = implementationTitle;
+    } else {
+      name = artifactName;
+    }
+
+    String version;
+    if (!bundleVersion.isEmpty() && bundleVersion.equals(implementationVersion)) {
+      version = bundleVersion;
+    } else {
+      version = firstNonEmpty(fileVersion, bundleVersion, implementationVersion);
+    }
+
+    String groupId = parseGroupId(bundleSymbolicName, artifactName);
+    if (!isValidGroupId(groupId)) {
+      groupId = parseGroupId(bundleSymbolicName, bundleName);
+    }
+    if (isValidGroupId(groupId)) {
+      name = groupId + ":" + name;
+    }
+    return new MetaDependency(name, version, sha1(metadata.inputStreamSupplier));
+  }
+
+  private static boolean isValidArtifactId(String value) {
+    return !value.isEmpty()
+        && value.indexOf(' ') < 0
+        && value.indexOf('.') < 0
+        && value.toLowerCase(Locale.ROOT).equals(value);
+  }
+
+  private static boolean isValidGroupId(String value) {
+    return !value.isEmpty()
+        && value.indexOf(' ') < 0
+        && value.indexOf('.') >= 0
+        && value.toLowerCase(Locale.ROOT).equals(value);
+  }
+
+  private static String parseGroupId(String symbolicName, String artifactName) {
+    if (symbolicName.isEmpty() || artifactName.isEmpty()) {
+      return "";
+    }
+    String artifactSuffix = "." + artifactName;
+    if (!symbolicName.endsWith(artifactSuffix)) {
+      return "";
+    }
+    String groupId = symbolicName.substring(0, symbolicName.length() - artifactSuffix.length());
+    return groupId.indexOf('.') >= 0 && groupId.length() > 5 ? groupId : "";
+  }
+
+  private static String manifestValue(Attributes attributes, String name) {
+    return metadataValue(attributes.getValue(name));
+  }
+
+  private static String firstNonEmpty(String... values) {
+    for (String value : values) {
+      if (!value.isEmpty()) {
+        return value;
+      }
+    }
+    return "";
+  }
+
+  private static String trim(@Nullable String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static String metadataValue(@Nullable String value) {
+    String result = trim(value);
+    return result.length() <= MAX_METADATA_VALUE_LENGTH ? result : "";
+  }
+
+  @Nullable
+  private static String sha1(InputStreamSupplier inputStreamSupplier) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-1");
+      try (InputStream inputStream = inputStreamSupplier.get()) {
+        byte[] buffer = new byte[8_192];
+        long totalBytes = 0;
+        int read;
+        while ((read = inputStream.read(buffer)) >= 0) {
+          if (Thread.currentThread().isInterrupted()) {
+            return null;
+          }
+          totalBytes += read;
+          if (totalBytes > MAX_HASH_BYTES) {
+            return null;
+          }
+          digest.update(buffer, 0, read);
+        }
+      }
+      byte[] hash = digest.digest();
+      char[] encoded = new char[hash.length * 2];
+      for (int i = 0; i < hash.length; i++) {
+        int value = hash[i] & 0xff;
+        encoded[i * 2] = HEX[value >>> 4];
+        encoded[i * 2 + 1] = HEX[value & 0x0f];
+      }
+      return new String(encoded);
+    } catch (IOException | NoSuchAlgorithmException e) {
+      logger.log(FINE, "Unable to hash Meta dependency", e);
+      return null;
+    }
+  }
+
+  private interface InputStreamSupplier {
+    InputStream get() throws IOException;
+  }
+
+  private static final class JarMetadata {
+    private final String jarName;
+    private final Map<String, Properties> pomProperties;
+    private final Attributes attributes;
+    private final InputStreamSupplier inputStreamSupplier;
+
+    private JarMetadata(
+        String jarName,
+        Map<String, Properties> pomProperties,
+        Attributes attributes,
+        InputStreamSupplier inputStreamSupplier) {
+      this.jarName = jarName;
+      this.pomProperties = pomProperties;
+      this.attributes = attributes;
+      this.inputStreamSupplier = inputStreamSupplier;
+    }
+  }
+
+  private static final class NestedJarInputStream extends InputStream {
+    private final JarFile outerJar;
+    private final InputStream inputStream;
+
+    private NestedJarInputStream(File outerJar, String innerJar) throws IOException {
+      this.outerJar = new JarFile(outerJar, false);
+      JarEntry entry = this.outerJar.getJarEntry(innerJar);
+      if (entry == null) {
+        this.outerJar.close();
+        throw new IOException("Nested JAR not found: " + innerJar);
+      }
+      this.inputStream = this.outerJar.getInputStream(entry);
+    }
+
+    @Override
+    public int read() throws IOException {
+      return inputStream.read();
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) throws IOException {
+      return inputStream.read(bytes, offset, length);
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        inputStream.close();
+      } finally {
+        outerJar.close();
+      }
+    }
+  }
+
+  private MetaDependencyResolver() {}
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaEvent.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.unmodifiableMap;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class MetaEvent {
+
+  private final long timestamp;
+  private final String requestType;
+  private final Map<String, Object> payload;
+
+  MetaEvent(long timestamp, String requestType, Map<String, Object> payload) {
+    this.timestamp = timestamp;
+    this.requestType = requestType;
+    this.payload = unmodifiableMap(new LinkedHashMap<>(payload));
+  }
+
+  long getTimestamp() {
+    return timestamp;
+  }
+
+  String getRequestType() {
+    return requestType;
+  }
+
+  Map<String, Object> getPayload() {
+    return payload;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaExportRequest.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaExportRequest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class MetaExportRequest {
+
+  private static final String API_VERSION = "v1";
+
+  private final long sequenceId;
+  private final long tracerTime;
+  private final String runtimeId;
+  private final Map<String, Object> resource;
+  private final List<MetaEvent> events;
+
+  MetaExportRequest(
+      long sequenceId,
+      long tracerTime,
+      String runtimeId,
+      Map<String, Object> resource,
+      List<MetaEvent> events) {
+    this.sequenceId = sequenceId;
+    this.tracerTime = tracerTime;
+    this.runtimeId = runtimeId;
+    this.resource = unmodifiableMap(new LinkedHashMap<>(resource));
+    this.events = unmodifiableList(new ArrayList<>(events));
+  }
+
+  String getApiVersion() {
+    return API_VERSION;
+  }
+
+  String getRuntimeId() {
+    return runtimeId;
+  }
+
+  long getSequenceId() {
+    return sequenceId;
+  }
+
+  long getTracerTime() {
+    return tracerTime;
+  }
+
+  Map<String, Object> getResource() {
+    return resource;
+  }
+
+  List<MetaEvent> getEvents() {
+    return events;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaExportResult.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaExportResult.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+enum MetaExportResult {
+  SUCCESS,
+  RETRYABLE_FAILURE,
+  PERMANENT_FAILURE
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaExporter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaExporter.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+interface MetaExporter {
+
+  MetaExportResult export(MetaExportRequest request);
+
+  default void shutdown() {}
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaInitializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.bootstrap.InstrumentationHolder;
+import io.opentelemetry.javaagent.tooling.BeforeAgentListener;
+import io.opentelemetry.javaagent.tooling.EmptyConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.lang.instrument.Instrumentation;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Initializes Meta event collectors before application instrumentations are installed. */
+@AutoService(BeforeAgentListener.class)
+public class MetaInitializer implements BeforeAgentListener {
+
+  private static final Logger logger = Logger.getLogger(MetaInitializer.class.getName());
+
+  @Override
+  public void beforeAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredSdk) {
+    ConfigProperties config = AutoConfigureUtil.getConfig(autoConfiguredSdk);
+    if (config == null) {
+      config = EmptyConfigProperties.INSTANCE;
+    }
+    initialize(config, InstrumentationHolder.getInstrumentation());
+  }
+
+  static void initialize(ConfigProperties config, @Nullable Instrumentation instrumentation) {
+    try {
+      if (instrumentation == null) {
+        logger.fine("Meta event collectors are disabled because Instrumentation is unavailable");
+        MetaTelemetry.disable();
+        return;
+      }
+      MetaTelemetry.initialize(MetaConfiguration.create(config), instrumentation);
+    } catch (IllegalArgumentException e) {
+      logger.log(FINE, "Meta event collectors are disabled: " + e.getMessage());
+      MetaTelemetry.disable();
+    } catch (RuntimeException | LinkageError e) {
+      logger.log(
+          WARNING,
+          "Meta event collectors failed to initialize and are disabled: {0}",
+          e.getClass().getName());
+      logger.log(FINE, "Meta event collector initialization failure", e);
+      MetaTelemetry.disable();
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaInstaller.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.AgentListener;
+import io.opentelemetry.javaagent.tooling.AgentVersion;
+import io.opentelemetry.javaagent.tooling.EmptyConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.SdkAutoconfigureAccess;
+import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Starts the dedicated meta exporter after Java agent installation. */
+@AutoService(AgentListener.class)
+public class MetaInstaller implements AgentListener {
+
+  private static final Logger logger = Logger.getLogger(MetaInstaller.class.getName());
+  private static final AtomicBoolean installed = new AtomicBoolean();
+
+  @Override
+  public void afterAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredSdk) {
+    if (!installed.compareAndSet(false, true)) {
+      return;
+    }
+
+    ConfigProperties config = AutoConfigureUtil.getConfig(autoConfiguredSdk);
+    if (config == null) {
+      config = EmptyConfigProperties.INSTANCE;
+    }
+    install(config, SdkAutoconfigureAccess.getResource(autoConfiguredSdk), AgentVersion.VERSION);
+  }
+
+  @Nullable
+  static MetaService install(
+      ConfigProperties config, Resource resource, @Nullable String agentVersion) {
+    MetaConfiguration configuration;
+    try {
+      configuration = MetaConfiguration.create(config);
+    } catch (IllegalArgumentException e) {
+      logger.log(WARNING, "Meta exporter is disabled: " + e.getMessage());
+      return null;
+    }
+    if (!configuration.isEnabled()) {
+      return null;
+    }
+    if (MetaTelemetry.isDisabled()) {
+      logger.warning("Meta exporter is disabled because its event collectors failed to initialize");
+      return null;
+    }
+
+    MetaService service = null;
+    try {
+      Map<String, Object> metaResource = MetaResource.from(resource, agentVersion);
+      service = new MetaService(new HttpMetaExporter(configuration), configuration, metaResource);
+      service.start();
+      if (configuration.isAppStartedEnabled()) {
+        service.emit("app-started", appStartedPayload(configuration));
+      }
+      MetaTelemetry.start(service);
+      addShutdownHook(service);
+      return service;
+    } catch (RuntimeException | LinkageError e) {
+      try {
+        if (service == null) {
+          MetaTelemetry.disable();
+        } else {
+          MetaTelemetry.shutdown(service);
+        }
+      } catch (RuntimeException | LinkageError cleanupError) {
+        e.addSuppressed(cleanupError);
+      }
+      logger.log(WARNING, "Meta exporter failed to start and is disabled", e);
+      return null;
+    }
+  }
+
+  private static Map<String, Object> appStartedPayload(MetaConfiguration configuration) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("installation_method", "javaagent");
+    payload.put("startup_status", "success");
+    List<String> enabledCapabilities = new ArrayList<>();
+    if (configuration.isAppStartedEnabled()) {
+      enabledCapabilities.add("app-started");
+    }
+    if (configuration.isAppDependenciesLoadedEnabled()) {
+      enabledCapabilities.add("app-dependencies-loaded");
+    }
+    if (configuration.isAppIntegrationsChangeEnabled()) {
+      enabledCapabilities.add("app-integrations-change");
+    }
+    enabledCapabilities.add("app-heartbeat");
+    enabledCapabilities.add("app-extended-heartbeat");
+    payload.put("enabled_capabilities", enabledCapabilities);
+    return payload;
+  }
+
+  private static void addShutdownHook(MetaService service) {
+    Thread shutdownHook =
+        new Thread(
+            () -> {
+              MetaTelemetry.shutdown(service);
+            },
+            "opentelemetry-meta-shutdown");
+    shutdownHook.setContextClassLoader(null);
+    try {
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
+    } catch (IllegalStateException ignored) {
+      MetaTelemetry.shutdown(service);
+    } catch (SecurityException e) {
+      logger.log(FINE, "Unable to register meta exporter shutdown hook", e);
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaIntegrationCollector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaIntegrationCollector.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.logging.Level.WARNING;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+final class MetaIntegrationCollector implements AutoCloseable {
+
+  private static final Logger logger = Logger.getLogger(MetaIntegrationCollector.class.getName());
+  private static final int MAX_INTEGRATIONS = 1_024;
+  private static final int MAX_INTEGRATION_NAME_LENGTH = 256;
+  private static final long POLL_DELAY_MILLIS = 200;
+
+  private final BlockingQueue<String> pending = new ArrayBlockingQueue<>(MAX_INTEGRATIONS);
+  private final Set<String> seen = ConcurrentHashMap.newKeySet();
+  private final AtomicBoolean running = new AtomicBoolean();
+  private final AtomicBoolean limitWarningLogged = new AtomicBoolean();
+  private final AtomicBoolean invalidNameWarningLogged = new AtomicBoolean();
+  private final Thread worker = new Thread(this::runWorker, "opentelemetry-meta-integrations");
+
+  private volatile List<Map<String, Object>> currentIntegrations = emptyList();
+
+  @Nullable private volatile MetaService service;
+
+  MetaIntegrationCollector() {
+    worker.setDaemon(true);
+    worker.setContextClassLoader(null);
+  }
+
+  void record(Iterable<String> instrumentationNames) {
+    for (String name : instrumentationNames) {
+      if (name == null || name.isEmpty() || seen.contains(name)) {
+        continue;
+      }
+      if (name.length() > MAX_INTEGRATION_NAME_LENGTH) {
+        if (invalidNameWarningLogged.compareAndSet(false, true)) {
+          logger.log(
+              WARNING,
+              "Meta integration names longer than {0} characters are ignored",
+              MAX_INTEGRATION_NAME_LENGTH);
+        }
+        continue;
+      }
+      if (seen.size() >= MAX_INTEGRATIONS) {
+        if (limitWarningLogged.compareAndSet(false, true)) {
+          logger.log(
+              WARNING,
+              "Meta integration limit of {0} was reached; additional integrations are ignored",
+              MAX_INTEGRATIONS);
+        }
+      } else if (seen.add(name) && !pending.offer(name)) {
+        seen.remove(name);
+        if (limitWarningLogged.compareAndSet(false, true)) {
+          logger.warning("Meta integration queue is full; an integration update was dropped");
+        }
+      }
+    }
+  }
+
+  void start(MetaService service) {
+    this.service = service;
+    if (running.compareAndSet(false, true)) {
+      worker.start();
+    }
+  }
+
+  private void runWorker() {
+    while (running.get() || !pending.isEmpty()) {
+      String first;
+      try {
+        first = pending.poll(POLL_DELAY_MILLIS, MILLISECONDS);
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      if (first == null) {
+        continue;
+      }
+
+      List<String> observedChanges = new ArrayList<>();
+      observedChanges.add(first);
+      pending.drainTo(observedChanges);
+      List<String> names = new ArrayList<>(seen);
+      Collections.sort(names);
+      List<Map<String, Object>> integrations = new ArrayList<>(names.size());
+      for (String name : names) {
+        Map<String, Object> integration = new LinkedHashMap<>();
+        integration.put("name", name);
+        integration.put("enabled", true);
+        integrations.add(integration);
+      }
+      integrations = Collections.unmodifiableList(integrations);
+      currentIntegrations = integrations;
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("integrations", integrations);
+      MetaService currentService = service;
+      if (currentService != null) {
+        currentService.emit("app-integrations-change", payload);
+      }
+    }
+  }
+
+  List<Map<String, Object>> snapshot() {
+    return currentIntegrations;
+  }
+
+  @Override
+  @SuppressWarnings("Interruption") // Cancels this collector's owned daemon after graceful timeout.
+  public void close() {
+    if (!running.compareAndSet(true, false)) {
+      return;
+    }
+    try {
+      worker.join(1_000);
+      if (worker.isAlive()) {
+        worker.interrupt();
+        logger.warning("Timed out waiting for the Meta integration collector to stop");
+      }
+    } catch (InterruptedException ignored) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaJsonSerializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaJsonSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+final class MetaJsonSerializer {
+
+  private final ObjectMapper objectMapper;
+
+  MetaJsonSerializer() {
+    this(new ObjectMapper());
+  }
+
+  MetaJsonSerializer(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  byte[] serialize(MetaExportRequest request) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    serialize(request, output);
+    return output.toByteArray();
+  }
+
+  void serialize(MetaExportRequest request, OutputStream output) throws IOException {
+    try (JsonGenerator generator = objectMapper.getFactory().createGenerator(output)) {
+      generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+      generator.writeStartObject();
+      generator.writeStringField("api_version", request.getApiVersion());
+      generator.writeStringField("runtime_id", request.getRuntimeId());
+      generator.writeNumberField("seq_id", request.getSequenceId());
+      generator.writeNumberField("tracer_time", request.getTracerTime());
+      generator.writeObjectField("resource", request.getResource());
+      generator.writeArrayFieldStart("events");
+      for (MetaEvent event : request.getEvents()) {
+        generator.writeStartObject();
+        generator.writeNumberField("timestamp", event.getTimestamp());
+        generator.writeStringField("request_type", event.getRequestType());
+        generator.writeObjectField("payload", event.getPayload());
+        generator.writeEndObject();
+      }
+      generator.writeEndArray();
+      generator.writeEndObject();
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaResource.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaResource.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableMap;
+
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+final class MetaResource {
+
+  @SuppressWarnings("InlineTrivialConstant") // Works around Error Prone DeduplicateConstants crash.
+  private static final String EMPTY = "";
+
+  private static final Path OS_RELEASE = Paths.get("/etc/os-release");
+  private static final Path PROC_VERSION = Paths.get("/proc/version");
+
+  private static final Set<String> ALLOWED_ATTRIBUTES =
+      new HashSet<>(
+          asList(
+              "service.name",
+              "service.namespace",
+              "service.version",
+              "service.instance.id",
+              "deployment.environment.name",
+              "telemetry.sdk.name",
+              "telemetry.sdk.language",
+              "telemetry.sdk.version",
+              "telemetry.distro.name",
+              "telemetry.distro.version",
+              "process.pid",
+              "process.executable.name",
+              "process.runtime.name",
+              "process.runtime.version",
+              "process.runtime.description",
+              "os.type",
+              "os.name",
+              "os.description",
+              "os.version",
+              "os.kernel.version",
+              "host.name",
+              "host.arch",
+              "host.id",
+              "container.id",
+              "container.name",
+              "k8s.cluster.name",
+              "k8s.namespace.name",
+              "k8s.node.name",
+              "k8s.pod.name",
+              "k8s.pod.uid"));
+
+  static Map<String, Object> from(Resource resource, @Nullable String agentVersion) {
+    Map<String, Object> result = new LinkedHashMap<>();
+    resource
+        .getAttributes()
+        .forEach(
+            (key, value) -> {
+              if (ALLOWED_ATTRIBUTES.contains(key.getKey())) {
+                result.put(key.getKey(), value);
+              }
+            });
+
+    putIfMissing(result, "telemetry.distro.version", agentVersion);
+    putIfMissing(result, "telemetry.sdk.language", "java");
+    putIfMissing(result, "process.runtime.name", property("java.runtime.name"));
+    putIfMissing(result, "process.runtime.version", property("java.runtime.version"));
+    putIfMissing(result, "process.runtime.description", runtimeDescription());
+    if (!result.containsKey("host.name")) {
+      putIfMissing(result, "host.name", hostname());
+    }
+    putIfMissing(result, "host.arch", normalizeArchitecture(property("os.arch")));
+    String osName = property("os.name");
+    putIfMissing(result, "os.type", normalizeOsType(osName));
+    putIfMissing(result, "os.name", osName);
+    putIfMissing(result, "os.version", property("os.version"));
+
+    if (shouldUseOsReleaseDescription(result)) {
+      String osDescription = osReleaseDescription();
+      if (!osDescription.isEmpty()) {
+        // The Linux distribution description is more useful than the JVM's kernel-only default.
+        result.put("os.description", osDescription);
+      }
+    }
+    if (!result.containsKey("os.kernel.version")) {
+      putIfMissing(result, "os.kernel.version", kernelVersion());
+    }
+    return unmodifiableMap(result);
+  }
+
+  private static boolean shouldUseOsReleaseDescription(Map<String, Object> resource) {
+    Object current = resource.get("os.description");
+    if (current == null) {
+      return true;
+    }
+    Object osName = resource.get("os.name");
+    Object osVersion = resource.get("os.version");
+    return osName != null
+        && osVersion != null
+        && current.toString().equals(osName + " " + osVersion);
+  }
+
+  private static void putIfMissing(
+      Map<String, Object> resource, String key, @Nullable String value) {
+    if (!resource.containsKey(key) && value != null && !value.isEmpty()) {
+      resource.put(key, value);
+    }
+  }
+
+  private static String hostname() {
+    try {
+      return emptyIfNull(InetAddress.getLocalHost().getHostName());
+    } catch (IOException | SecurityException ignored) {
+      return EMPTY;
+    }
+  }
+
+  private static String runtimeDescription() {
+    String vendor = property("java.vm.vendor");
+    String name = property("java.vm.name");
+    String version = property("java.vm.version");
+    return joinNonEmpty(vendor, name, version);
+  }
+
+  private static String normalizeArchitecture(String architecture) {
+    switch (architecture.toLowerCase(Locale.ROOT)) {
+      case "x86_64":
+      case "amd64":
+        return "amd64";
+      case "x86":
+      case "i386":
+      case "i486":
+      case "i586":
+      case "i686":
+        return "x86";
+      case "aarch64":
+      case "arm64":
+        return "arm64";
+      case "arm":
+      case "arm32":
+        return "arm32";
+      case "ppc":
+      case "ppc32":
+        return "ppc32";
+      case "ppc64":
+      case "ppc64le":
+        return "ppc64";
+      default:
+        return architecture;
+    }
+  }
+
+  private static String normalizeOsType(String osName) {
+    String normalized = osName.toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("windows")) {
+      return "windows";
+    }
+    if (normalized.startsWith("mac") || normalized.startsWith("darwin")) {
+      return "darwin";
+    }
+    if (normalized.startsWith("linux")) {
+      return "linux";
+    }
+    if (normalized.startsWith("sunos")) {
+      return "solaris";
+    }
+    if (normalized.startsWith("hp-ux")) {
+      return "hpux";
+    }
+    return normalized.replace('-', '_').replace(' ', '_');
+  }
+
+  private static String osReleaseDescription() {
+    try {
+      if (!Files.isRegularFile(OS_RELEASE)) {
+        return EMPTY;
+      }
+      String name = EMPTY;
+      String version = EMPTY;
+      for (String line : Files.readAllLines(OS_RELEASE, ISO_8859_1)) {
+        int separator = line.indexOf('=');
+        if (separator <= 0) {
+          continue;
+        }
+        String key = line.substring(0, separator);
+        String value = unquote(line.substring(separator + 1));
+        if ("PRETTY_NAME".equals(key) && !value.isEmpty()) {
+          return value;
+        }
+        if ("NAME".equals(key)) {
+          name = value;
+        } else if ("VERSION".equals(key)) {
+          version = value;
+        }
+      }
+      return joinNonEmpty(name, version);
+    } catch (IOException | SecurityException ignored) {
+      return EMPTY;
+    }
+  }
+
+  private static String kernelVersion() {
+    try {
+      if (!Files.isRegularFile(PROC_VERSION)) {
+        return EMPTY;
+      }
+      List<String> lines = Files.readAllLines(PROC_VERSION, ISO_8859_1);
+      if (lines.isEmpty()) {
+        return EMPTY;
+      }
+      String version = lines.get(0).trim();
+      int buildMarker = version.indexOf('#');
+      return buildMarker < 0 ? version : version.substring(buildMarker);
+    } catch (IOException | SecurityException ignored) {
+      return EMPTY;
+    }
+  }
+
+  private static String property(String name) {
+    try {
+      return emptyIfNull(System.getProperty(name));
+    } catch (SecurityException ignored) {
+      return EMPTY;
+    }
+  }
+
+  private static String joinNonEmpty(String... values) {
+    StringBuilder result = new StringBuilder();
+    for (String value : values) {
+      if (value.isEmpty()) {
+        continue;
+      }
+      if (result.length() > 0) {
+        result.append(' ');
+      }
+      result.append(value);
+    }
+    return result.toString();
+  }
+
+  private static String unquote(String value) {
+    String trimmed = value.trim();
+    if (trimmed.length() >= 2 && trimmed.charAt(0) == '"' && trimmed.endsWith("\"")) {
+      return trimmed.substring(1, trimmed.length() - 1);
+    }
+    return trimmed;
+  }
+
+  private static String emptyIfNull(@Nullable String value) {
+    return value == null ? EMPTY : value;
+  }
+
+  private MetaResource() {}
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaService.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaService.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.emptyMap;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.logging.Level.WARNING;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+final class MetaService implements AutoCloseable {
+
+  private static final Logger logger = Logger.getLogger(MetaService.class.getName());
+  private static final int MAX_EVENTS_PER_REQUEST = 5;
+
+  private final MetaExporter exporter;
+  // State is retained in pendingStateEvents. This single-slot queue only wakes the worker.
+  private final BlockingQueue<Boolean> wakeup = new ArrayBlockingQueue<>(1);
+  private final long scheduleDelayMillis;
+  private final long shutdownTimeoutMillis;
+  private final long heartbeatIntervalNanos;
+  private final long extendedHeartbeatIntervalNanos;
+  private final Supplier<Map<String, Object>> extendedHeartbeatPayloadSupplier;
+  private final String runtimeId;
+  private final Map<String, Object> resource;
+  private final AtomicLong sequenceId = new AtomicLong();
+  private final AtomicLong failedExports = new AtomicLong();
+  private final AtomicBoolean running = new AtomicBoolean();
+  private final Thread workerThread;
+
+  // Guarded by this. Stateful events retain only their latest value until a successful export.
+  private final Map<String, MetaEvent> pendingStateEvents = new LinkedHashMap<>();
+  private final Map<String, MetaEvent> deferredStateEvents = new LinkedHashMap<>();
+
+  // Accessed only by workerThread.
+  private long nextHeartbeatNanos = Long.MAX_VALUE;
+  private long nextExtendedHeartbeatNanos = Long.MAX_VALUE;
+  private boolean extendedHeartbeatPending;
+  private boolean extendedHeartbeatReady;
+
+  MetaService(
+      MetaExporter exporter, MetaConfiguration configuration, Map<String, Object> resource) {
+    this(
+        exporter,
+        configuration.getScheduleDelayMillis(),
+        configuration.getShutdownTimeoutMillis(),
+        configuration.getHeartbeatIntervalMillis(),
+        configuration.getExtendedHeartbeatIntervalMillis(),
+        UUID.randomUUID().toString(),
+        resource,
+        MetaTelemetry::extendedHeartbeatPayload);
+  }
+
+  MetaService(
+      MetaExporter exporter,
+      long scheduleDelayMillis,
+      long shutdownTimeoutMillis,
+      String runtimeId,
+      Map<String, Object> resource) {
+    this(
+        exporter,
+        scheduleDelayMillis,
+        shutdownTimeoutMillis,
+        0,
+        0,
+        runtimeId,
+        resource,
+        Collections::emptyMap);
+  }
+
+  MetaService(
+      MetaExporter exporter,
+      long scheduleDelayMillis,
+      long shutdownTimeoutMillis,
+      long heartbeatIntervalMillis,
+      long extendedHeartbeatIntervalMillis,
+      String runtimeId,
+      Map<String, Object> resource,
+      Supplier<Map<String, Object>> extendedHeartbeatPayloadSupplier) {
+    this.exporter = exporter;
+    this.scheduleDelayMillis = scheduleDelayMillis;
+    this.shutdownTimeoutMillis = shutdownTimeoutMillis;
+    this.heartbeatIntervalNanos = MILLISECONDS.toNanos(heartbeatIntervalMillis);
+    this.extendedHeartbeatIntervalNanos = MILLISECONDS.toNanos(extendedHeartbeatIntervalMillis);
+    this.runtimeId = runtimeId;
+    this.resource = resource;
+    this.extendedHeartbeatPayloadSupplier = extendedHeartbeatPayloadSupplier;
+    this.workerThread = new Thread(this::runWorker, "opentelemetry-meta-exporter");
+    this.workerThread.setDaemon(true);
+    this.workerThread.setContextClassLoader(null);
+  }
+
+  void start() {
+    if (running.compareAndSet(false, true)) {
+      workerThread.start();
+    }
+  }
+
+  synchronized boolean emit(String requestType, Map<String, Object> payload) {
+    if (!running.get()) {
+      return false;
+    }
+    MetaEvent event = new MetaEvent(System.currentTimeMillis() / 1000, requestType, payload);
+    if (!isStateful(requestType)) {
+      return false;
+    }
+    pendingStateEvents.put(requestType, event);
+    deferredStateEvents.remove(requestType);
+    signalStateChange();
+    return true;
+  }
+
+  long getFailedExports() {
+    return failedExports.get();
+  }
+
+  String getRuntimeId() {
+    return runtimeId;
+  }
+
+  private void runWorker() {
+    try {
+      long startedAt = System.nanoTime();
+      if (heartbeatIntervalNanos > 0) {
+        nextHeartbeatNanos = nextDeadline(startedAt, heartbeatIntervalNanos);
+      }
+      if (extendedHeartbeatIntervalNanos > 0) {
+        nextExtendedHeartbeatNanos = nextDeadline(startedAt, extendedHeartbeatIntervalNanos);
+      }
+
+      while (running.get() || hasReadyStateEvents()) {
+        List<MetaEvent> batch = new ArrayList<>(MAX_EVENTS_PER_REQUEST);
+        appendScheduledEvents(batch, System.nanoTime());
+        boolean stateReadyWithoutSignal = hasReadyStateEvents() && wakeup.isEmpty();
+        if (batch.isEmpty() && !stateReadyWithoutSignal) {
+          Boolean stateChanged;
+          try {
+            long waitNanos = nanosUntilScheduledEvent(System.nanoTime());
+            stateChanged =
+                waitNanos == Long.MAX_VALUE ? wakeup.take() : wakeup.poll(waitNanos, NANOSECONDS);
+          } catch (InterruptedException ignored) {
+            if (running.get()) {
+              continue;
+            }
+            stateChanged = wakeup.poll();
+          }
+          if (stateChanged == null) {
+            continue;
+          }
+          collectBatch();
+        }
+
+        appendScheduledEvents(batch, System.nanoTime());
+        appendReadyStateEvents(batch);
+        if (batch.isEmpty()) {
+          continue;
+        }
+
+        boolean containsExtendedHeartbeat = containsEvent(batch, "app-extended-heartbeat");
+        MetaExportResult result = MetaExportResult.RETRYABLE_FAILURE;
+        try {
+          result =
+              exporter.export(
+                  new MetaExportRequest(
+                      sequenceId.incrementAndGet(),
+                      System.currentTimeMillis() / 1000,
+                      runtimeId,
+                      resource,
+                      batch));
+        } catch (RuntimeException e) {
+          logger.log(WARNING, "Meta exporter failed unexpectedly", e);
+        }
+        if (result == MetaExportResult.SUCCESS) {
+          acknowledgeStateEvents(batch);
+          if (containsExtendedHeartbeat) {
+            extendedHeartbeatPending = false;
+          }
+        } else {
+          failedExports.incrementAndGet();
+          if (result == MetaExportResult.RETRYABLE_FAILURE) {
+            deferStateEvents(batch);
+          } else {
+            acknowledgeStateEvents(batch);
+            if (containsExtendedHeartbeat) {
+              extendedHeartbeatPending = false;
+            }
+          }
+        }
+      }
+    } catch (Throwable t) {
+      logger.log(WARNING, "Meta exporter worker stopped unexpectedly", t);
+    } finally {
+      exporter.shutdown();
+    }
+  }
+
+  private void collectBatch() {
+    long batchDeadline = nextDeadline(System.nanoTime(), MILLISECONDS.toNanos(scheduleDelayMillis));
+    while (running.get()) {
+      long now = System.nanoTime();
+      long remainingNanos = Math.min(batchDeadline - now, nanosUntilScheduledEvent(now));
+      if (remainingNanos <= 0) {
+        break;
+      }
+      Boolean stateChanged;
+      try {
+        stateChanged = wakeup.poll(remainingNanos, NANOSECONDS);
+      } catch (InterruptedException ignored) {
+        if (running.get()) {
+          continue;
+        }
+        break;
+      }
+      if (stateChanged == null) {
+        break;
+      }
+    }
+  }
+
+  private long nanosUntilScheduledEvent(long now) {
+    if (!running.get()) {
+      return Long.MAX_VALUE;
+    }
+    if (extendedHeartbeatReady) {
+      return 0;
+    }
+    long nextDeadline = Math.min(nextHeartbeatNanos, nextExtendedHeartbeatNanos);
+    if (nextDeadline == Long.MAX_VALUE) {
+      return Long.MAX_VALUE;
+    }
+    long remaining = nextDeadline - now;
+    return remaining <= 0 ? 0 : remaining;
+  }
+
+  private void appendScheduledEvents(List<MetaEvent> batch, long now) {
+    if (!running.get()) {
+      return;
+    }
+
+    if (nextExtendedHeartbeatNanos <= now) {
+      nextExtendedHeartbeatNanos = nextDeadline(now, extendedHeartbeatIntervalNanos);
+      extendedHeartbeatPending = true;
+      extendedHeartbeatReady = true;
+    }
+
+    if (nextHeartbeatNanos <= now && batch.size() < MAX_EVENTS_PER_REQUEST) {
+      batch.add(newEvent("app-heartbeat", emptyMap()));
+      nextHeartbeatNanos = nextDeadline(now, heartbeatIntervalNanos);
+      retryDeferredStateEvents();
+      if (extendedHeartbeatPending) {
+        extendedHeartbeatReady = true;
+      }
+    }
+
+    if (extendedHeartbeatReady && batch.size() < MAX_EVENTS_PER_REQUEST) {
+      try {
+        batch.add(newEvent("app-extended-heartbeat", extendedHeartbeatPayloadSupplier.get()));
+      } catch (RuntimeException e) {
+        logger.log(WARNING, "Unable to create the Meta extended heartbeat payload", e);
+      }
+      extendedHeartbeatReady = false;
+    }
+  }
+
+  private static MetaEvent newEvent(String requestType, Map<String, Object> payload) {
+    return new MetaEvent(System.currentTimeMillis() / 1000, requestType, payload);
+  }
+
+  private static boolean containsEvent(List<MetaEvent> events, String requestType) {
+    for (MetaEvent event : events) {
+      if (event.getRequestType().equals(requestType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void signalStateChange() {
+    wakeup.offer(Boolean.TRUE);
+  }
+
+  private synchronized boolean hasReadyStateEvents() {
+    for (Map.Entry<String, MetaEvent> entry : pendingStateEvents.entrySet()) {
+      if (deferredStateEvents.get(entry.getKey()) != entry.getValue()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private synchronized void appendReadyStateEvents(List<MetaEvent> batch) {
+    for (Map.Entry<String, MetaEvent> entry : pendingStateEvents.entrySet()) {
+      if (batch.size() >= MAX_EVENTS_PER_REQUEST) {
+        return;
+      }
+      if (deferredStateEvents.get(entry.getKey()) != entry.getValue()) {
+        batch.add(entry.getValue());
+      }
+    }
+  }
+
+  private synchronized void acknowledgeStateEvents(List<MetaEvent> events) {
+    for (MetaEvent event : events) {
+      String requestType = event.getRequestType();
+      if (pendingStateEvents.get(requestType) == event) {
+        pendingStateEvents.remove(requestType);
+        deferredStateEvents.remove(requestType);
+      }
+    }
+  }
+
+  private synchronized void deferStateEvents(List<MetaEvent> events) {
+    for (MetaEvent event : events) {
+      String requestType = event.getRequestType();
+      if (pendingStateEvents.get(requestType) == event) {
+        deferredStateEvents.put(requestType, event);
+      }
+    }
+  }
+
+  private synchronized void retryDeferredStateEvents() {
+    deferredStateEvents.clear();
+  }
+
+  private static boolean isStateful(String requestType) {
+    return requestType.equals("app-started")
+        || requestType.equals("app-dependencies-loaded")
+        || requestType.equals("app-integrations-change");
+  }
+
+  private static long nextDeadline(long now, long interval) {
+    return now > Long.MAX_VALUE - interval ? Long.MAX_VALUE : now + interval;
+  }
+
+  @Override
+  @SuppressWarnings("Interruption") // Wakes this service's owned worker so shutdown can flush now.
+  public void close() {
+    if (!running.compareAndSet(true, false)) {
+      return;
+    }
+    retryDeferredStateEvents();
+    signalStateChange();
+    if (Thread.currentThread() == workerThread) {
+      return;
+    }
+    workerThread.interrupt();
+    try {
+      workerThread.join(shutdownTimeoutMillis);
+      if (workerThread.isAlive()) {
+        logger.log(
+            WARNING,
+            "Timed out after {0} ms waiting for the Meta exporter worker to stop; an in-flight export may continue on its daemon thread",
+            shutdownTimeoutMillis);
+      }
+    } catch (InterruptedException ignored) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaTelemetry.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaTelemetry.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.emptyList;
+import static java.util.logging.Level.FINE;
+
+import java.lang.instrument.Instrumentation;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Coordinates Meta collectors that run before and after Java agent installation. */
+public final class MetaTelemetry {
+
+  private static final Logger logger = Logger.getLogger(MetaTelemetry.class.getName());
+  private static final Object lock = new Object();
+
+  @Nullable private static volatile MetaDependencyCollector dependencyCollector;
+  @Nullable private static volatile MetaIntegrationCollector integrationCollector;
+  @Nullable private static volatile Instrumentation instrumentation;
+  private static final PendingIntegrations pendingIntegrations = new PendingIntegrations();
+  private static boolean initialized;
+  private static volatile boolean disabled;
+
+  static void initialize(MetaConfiguration configuration, Instrumentation instrumentation) {
+    synchronized (lock) {
+      if (initialized) {
+        return;
+      }
+      initialized = true;
+      if (!configuration.isEnabled()) {
+        return;
+      }
+
+      MetaDependencyCollector dependencies = null;
+      boolean dependencyTransformerAdded = false;
+      try {
+        if (configuration.isAppDependenciesLoadedEnabled()) {
+          dependencies = new MetaDependencyCollector();
+          instrumentation.addTransformer(dependencies);
+          dependencyTransformerAdded = true;
+        }
+        MetaIntegrationCollector integrations =
+            configuration.isAppIntegrationsChangeEnabled() ? new MetaIntegrationCollector() : null;
+
+        dependencyCollector = dependencies;
+        integrationCollector = integrations;
+        MetaTelemetry.instrumentation = dependencyTransformerAdded ? instrumentation : null;
+        disabled = false;
+      } catch (RuntimeException | LinkageError e) {
+        if (dependencyTransformerAdded && dependencies != null) {
+          try {
+            instrumentation.removeTransformer(dependencies);
+          } catch (RuntimeException | LinkageError cleanupError) {
+            e.addSuppressed(cleanupError);
+          }
+        }
+        throw e;
+      }
+    }
+  }
+
+  static void disable() {
+    MetaDependencyCollector dependencies;
+    MetaIntegrationCollector integrations;
+    Instrumentation currentInstrumentation;
+    synchronized (lock) {
+      initialized = true;
+      disabled = true;
+      dependencies = dependencyCollector;
+      integrations = integrationCollector;
+      currentInstrumentation = instrumentation;
+      dependencyCollector = null;
+      integrationCollector = null;
+      instrumentation = null;
+    }
+    if (dependencies != null && currentInstrumentation != null) {
+      try {
+        currentInstrumentation.removeTransformer(dependencies);
+      } catch (RuntimeException | LinkageError e) {
+        logger.log(FINE, "Unable to remove the Meta dependency transformer", e);
+      }
+    }
+    if (dependencies != null) {
+      closeCollector(dependencies, "dependency");
+    }
+    if (integrations != null) {
+      closeCollector(integrations, "integration");
+    }
+  }
+
+  static boolean isDisabled() {
+    return disabled;
+  }
+
+  static void resetForTest() {
+    disable();
+    synchronized (lock) {
+      initialized = false;
+      disabled = false;
+    }
+  }
+
+  /** Returns whether successful instrumentation transformations should be collected. */
+  public static boolean isIntegrationCollectionEnabled() {
+    return integrationCollector != null;
+  }
+
+  /** Records an instrumentation whose type matcher and transformation chain were selected. */
+  public static void integrationMatched(String typeName, String instrumentationName) {
+    if (integrationCollector == null
+        || typeName == null
+        || typeName.isEmpty()
+        || instrumentationName == null
+        || instrumentationName.isEmpty()) {
+      return;
+    }
+    pendingIntegrations.add(typeName, instrumentationName);
+  }
+
+  /** Commits integrations only after Byte Buddy reports a successful class transformation. */
+  public static void integrationTransformationSucceeded(String typeName) {
+    Set<String> names = pendingIntegrations.remove(typeName);
+    MetaIntegrationCollector collector = integrationCollector;
+    if (collector != null && names != null && !names.isEmpty()) {
+      collector.record(names);
+    }
+  }
+
+  /** Clears instrumentation matches when transformation fails or completes without a transform. */
+  public static void integrationTransformationFinished(String typeName) {
+    pendingIntegrations.remove(typeName);
+  }
+
+  static void start(MetaService service) {
+    MetaDependencyCollector dependencies = dependencyCollector;
+    if (dependencies != null) {
+      dependencies.start(service);
+    }
+    MetaIntegrationCollector integrations = integrationCollector;
+    if (integrations != null) {
+      integrations.start(service);
+    }
+  }
+
+  static Map<String, Object> extendedHeartbeatPayload() {
+    MetaDependencyCollector dependencies = dependencyCollector;
+    MetaIntegrationCollector integrations = integrationCollector;
+    Map<String, Object> payload = new LinkedHashMap<>();
+    // Reserved for allowlisted agent configuration telemetry. Never expose raw configuration,
+    // because exporter headers and other settings can contain credentials.
+    payload.put("configuration", emptyList());
+    payload.put("dependencies", dependencies == null ? emptyList() : dependencies.snapshot());
+    payload.put("integrations", integrations == null ? emptyList() : integrations.snapshot());
+    return payload;
+  }
+
+  static void shutdown(MetaService service) {
+    MetaDependencyCollector dependencies;
+    MetaIntegrationCollector integrations;
+    Instrumentation currentInstrumentation;
+    synchronized (lock) {
+      dependencies = dependencyCollector;
+      integrations = integrationCollector;
+      currentInstrumentation = instrumentation;
+    }
+
+    // Keep the collectors visible to extended heartbeats until collection and export have stopped.
+    if (dependencies != null && currentInstrumentation != null) {
+      try {
+        currentInstrumentation.removeTransformer(dependencies);
+      } catch (RuntimeException | LinkageError e) {
+        logger.log(FINE, "Unable to remove the Meta dependency transformer", e);
+      }
+    }
+    if (dependencies != null) {
+      closeCollector(dependencies, "dependency");
+    }
+    if (integrations != null) {
+      closeCollector(integrations, "integration");
+    }
+    try {
+      service.close();
+    } catch (RuntimeException | LinkageError e) {
+      logger.log(FINE, "Unable to stop the Meta service", e);
+    } finally {
+      synchronized (lock) {
+        if (dependencyCollector == dependencies) {
+          dependencyCollector = null;
+        }
+        if (integrationCollector == integrations) {
+          integrationCollector = null;
+        }
+        if (instrumentation == currentInstrumentation) {
+          instrumentation = null;
+        }
+      }
+    }
+  }
+
+  private static void closeCollector(AutoCloseable collector, String collectorName) {
+    try {
+      collector.close();
+    } catch (Exception | LinkageError e) {
+      logger.log(FINE, "Unable to stop the Meta " + collectorName + " collector", e);
+    }
+  }
+
+  static final class PendingIntegrations {
+    private static final ThreadLocal<Map<String, Set<String>>> pending = new ThreadLocal<>();
+
+    void add(String typeName, String instrumentationName) {
+      Map<String, Set<String>> integrationsByType = pending.get();
+      if (integrationsByType == null) {
+        integrationsByType = new LinkedHashMap<>();
+        pending.set(integrationsByType);
+      }
+      integrationsByType
+          .computeIfAbsent(typeName, unused -> new LinkedHashSet<>())
+          .add(instrumentationName);
+    }
+
+    @Nullable
+    Set<String> remove(String typeName) {
+      Map<String, Set<String>> integrationsByType = pending.get();
+      if (integrationsByType == null) {
+        return null;
+      }
+      Set<String> result = integrationsByType.remove(typeName);
+      if (integrationsByType.isEmpty()) {
+        pending.remove();
+      }
+      return result;
+    }
+  }
+
+  private MetaTelemetry() {}
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaTransformationListener.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/meta/MetaTransformationListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.utility.JavaModule;
+
+/** Correlates Meta integration matches with the final result of a Byte Buddy transformation. */
+public class MetaTransformationListener extends AgentBuilder.Listener.Adapter {
+
+  @Override
+  public void onTransformation(
+      TypeDescription typeDescription,
+      ClassLoader classLoader,
+      JavaModule module,
+      boolean loaded,
+      DynamicType dynamicType) {
+    MetaTelemetry.integrationTransformationSucceeded(typeDescription.getName());
+  }
+
+  @Override
+  public void onError(
+      String typeName,
+      ClassLoader classLoader,
+      JavaModule module,
+      boolean loaded,
+      Throwable throwable) {
+    MetaTelemetry.integrationTransformationFinished(typeName);
+  }
+
+  @Override
+  public void onComplete(
+      String typeName, ClassLoader classLoader, JavaModule module, boolean loaded) {
+    MetaTelemetry.integrationTransformationFinished(typeName);
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/HttpMetaExporterTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/HttpMetaExporterTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.logging.Level.ALL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.zip.GZIPInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class HttpMetaExporterTest {
+
+  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  @Test
+  void sendsGzipJsonRequest() throws Exception {
+    CountDownLatch received = new CountDownLatch(1);
+    AtomicReference<byte[]> requestBody = new AtomicReference<>();
+    AtomicReference<String> contentEncoding = new AtomicReference<>();
+    AtomicReference<String> authorization = new AtomicReference<>();
+    HttpServer server = startServer();
+    server.createContext(
+        "/v1/meta",
+        exchange -> {
+          requestBody.set(readAll(exchange.getRequestBody()));
+          contentEncoding.set(exchange.getRequestHeaders().getFirst("Content-Encoding"));
+          authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+          exchange.sendResponseHeaders(204, -1);
+          exchange.close();
+          received.countDown();
+        });
+
+    HttpMetaExporter exporter =
+        exporter(server, singletonMap("Authorization", "Bearer token"), true, 0, ignored -> {});
+
+    assertThat(exporter.export(request())).isEqualTo(MetaExportResult.SUCCESS);
+    assertThat(received.await(5, SECONDS)).isTrue();
+    assertThat(contentEncoding.get()).isEqualTo("gzip");
+    assertThat(authorization.get()).isEqualTo("Bearer token");
+
+    byte[] uncompressed = gunzip(requestBody.get());
+    JsonNode root = new ObjectMapper().readTree(new String(uncompressed, UTF_8));
+    assertThat(root.get("events").get(0).get("request_type").asText()).isEqualTo("app-started");
+  }
+
+  @Test
+  void retriesRetryableResponse() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    HttpServer server = startServer();
+    server.createContext(
+        "/v1/meta",
+        exchange -> {
+          int status = requests.incrementAndGet() == 1 ? 500 : 204;
+          exchange.sendResponseHeaders(status, -1);
+          exchange.close();
+        });
+
+    HttpMetaExporter exporter = exporter(server, emptyMap(), false, 1, ignored -> {});
+
+    List<LogRecord> logs =
+        captureLogs(
+            () -> assertThat(exporter.export(request())).isEqualTo(MetaExportResult.SUCCESS));
+    assertThat(requests).hasValue(2);
+    assertThat(logMessages(logs))
+        .filteredOn(message -> message.startsWith("Meta export succeeded"))
+        .singleElement()
+        .asString()
+        .contains("status_code=204", "seq_id=1", "event_count=1", "attempts=2");
+  }
+
+  @Test
+  void doesNotRetryPermanentClientError() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    HttpServer server = startServer();
+    server.createContext(
+        "/v1/meta",
+        exchange -> {
+          requests.incrementAndGet();
+          exchange.sendResponseHeaders(400, -1);
+          exchange.close();
+        });
+
+    HttpMetaExporter exporter = exporter(server, emptyMap(), false, 3, ignored -> {});
+
+    List<LogRecord> logs =
+        captureLogs(
+            () ->
+                assertThat(exporter.export(request()))
+                    .isEqualTo(MetaExportResult.PERMANENT_FAILURE));
+    assertThat(requests).hasValue(1);
+    assertThat(logMessages(logs))
+        .filteredOn(message -> message.startsWith("Meta export failed"))
+        .singleElement()
+        .asString()
+        .contains(
+            "status_code=400", "seq_id=1", "event_count=1", "attempts=1", "reason=http_response");
+  }
+
+  @Test
+  void logsNetworkFailureAfterRetriesAreExhausted() throws Exception {
+    HttpServer unavailableServer =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    unavailableServer.start();
+    int unavailablePort = unavailableServer.getAddress().getPort();
+    unavailableServer.stop(0);
+    URL endpoint = new URL("http://127.0.0.1:" + unavailablePort + "/v1/meta");
+    HttpMetaExporter exporter =
+        new HttpMetaExporter(
+            endpoint, emptyMap(), 1000, false, 1, new MetaJsonSerializer(), ignored -> {});
+
+    List<LogRecord> logs =
+        captureLogs(
+            () ->
+                assertThat(exporter.export(request()))
+                    .isEqualTo(MetaExportResult.RETRYABLE_FAILURE));
+
+    assertThat(logMessages(logs))
+        .filteredOn(message -> message.startsWith("Meta export failed"))
+        .singleElement()
+        .asString()
+        .contains(
+            "endpoint=http://127.0.0.1:" + unavailablePort + "/v1/meta",
+            "status_code=unavailable",
+            "seq_id=1",
+            "attempts=2",
+            "reason=java.net.ConnectException");
+  }
+
+  @Test
+  void rejectsRequestLargerThanConfiguredLimit() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    HttpServer server = startServer();
+    server.createContext(
+        "/v1/meta",
+        exchange -> {
+          requests.incrementAndGet();
+          exchange.sendResponseHeaders(204, -1);
+          exchange.close();
+        });
+    URL endpoint = new URL("http://127.0.0.1:" + server.getAddress().getPort() + "/v1/meta");
+    HttpMetaExporter exporter =
+        new HttpMetaExporter(
+            endpoint, emptyMap(), 1000, false, 0, 32, new MetaJsonSerializer(), ignored -> {});
+
+    List<LogRecord> logs =
+        captureLogs(
+            () ->
+                assertThat(exporter.export(request()))
+                    .isEqualTo(MetaExportResult.PERMANENT_FAILURE));
+
+    assertThat(requests).hasValue(0);
+    assertThat(logMessages(logs))
+        .filteredOn(message -> message.startsWith("Meta export failed"))
+        .singleElement()
+        .asString()
+        .contains("attempts=0", "reason=request_too_large");
+  }
+
+  @Test
+  void limitsUncompressedJsonWhileStreamingGzipRequest() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    HttpServer server = startServer();
+    server.createContext(
+        "/v1/meta",
+        exchange -> {
+          requests.incrementAndGet();
+          exchange.sendResponseHeaders(204, -1);
+          exchange.close();
+        });
+    URL endpoint = new URL("http://127.0.0.1:" + server.getAddress().getPort() + "/v1/meta");
+    HttpMetaExporter exporter =
+        new HttpMetaExporter(
+            endpoint, emptyMap(), 1000, true, 0, 512, new MetaJsonSerializer(), ignored -> {});
+    char[] largeValue = new char[16 * 1024];
+    Arrays.fill(largeValue, 'a');
+
+    List<LogRecord> logs =
+        captureLogs(
+            () ->
+                assertThat(exporter.export(request(singletonMap("value", new String(largeValue)))))
+                    .isEqualTo(MetaExportResult.PERMANENT_FAILURE));
+
+    assertThat(requests).hasValue(0);
+    assertThat(logMessages(logs))
+        .filteredOn(message -> message.startsWith("Meta export failed"))
+        .singleElement()
+        .asString()
+        .contains("attempts=0", "reason=request_too_large");
+  }
+
+  private static HttpServer startServer() throws IOException {
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.start();
+    cleanup.deferCleanup(() -> server.stop(0));
+    return server;
+  }
+
+  private static HttpMetaExporter exporter(
+      HttpServer server,
+      Map<String, String> headers,
+      boolean gzipEnabled,
+      int maxRetries,
+      HttpMetaExporter.Sleeper sleeper)
+      throws Exception {
+    URL endpoint = new URL("http://127.0.0.1:" + server.getAddress().getPort() + "/v1/meta");
+    return new HttpMetaExporter(
+        endpoint, headers, 1000, gzipEnabled, maxRetries, new MetaJsonSerializer(), sleeper);
+  }
+
+  private static MetaExportRequest request() {
+    return request(singletonMap("startup_status", "success"));
+  }
+
+  private static MetaExportRequest request(Map<String, ?> payload) {
+    Map<String, Object> normalizedPayload = new LinkedHashMap<>();
+    normalizedPayload.putAll(payload);
+    MetaEvent event = new MetaEvent(1234, "app-started", normalizedPayload);
+    return new MetaExportRequest(1, 1234, "runtime-id", emptyMap(), singletonList(event));
+  }
+
+  private static byte[] readAll(InputStream inputStream) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int read;
+    while ((read = inputStream.read(buffer)) >= 0) {
+      outputStream.write(buffer, 0, read);
+    }
+    return outputStream.toByteArray();
+  }
+
+  private static byte[] gunzip(byte[] value) throws IOException {
+    try (GZIPInputStream inputStream = new GZIPInputStream(new ByteArrayInputStream(value))) {
+      return readAll(inputStream);
+    }
+  }
+
+  private static List<LogRecord> captureLogs(Runnable action) {
+    Logger exporterLogger = Logger.getLogger(HttpMetaExporter.class.getName());
+    Level originalLevel = exporterLogger.getLevel();
+    List<LogRecord> records = new CopyOnWriteArrayList<>();
+    Handler handler =
+        new Handler() {
+          @Override
+          public void publish(LogRecord record) {
+            records.add(record);
+          }
+
+          @Override
+          public void flush() {}
+
+          @Override
+          public void close() {}
+        };
+    handler.setLevel(ALL);
+    exporterLogger.setLevel(ALL);
+    exporterLogger.addHandler(handler);
+    try {
+      action.run();
+    } finally {
+      exporterLogger.removeHandler(handler);
+      exporterLogger.setLevel(originalLevel);
+    }
+    return records;
+  }
+
+  private static List<String> logMessages(List<LogRecord> records) {
+    SimpleFormatter formatter = new SimpleFormatter();
+    List<String> messages = new ArrayList<>();
+    for (LogRecord record : records) {
+      messages.add(formatter.formatMessage(record));
+    }
+    return messages;
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaCollectorsTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaCollectorsTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MetaCollectorsTest {
+
+  @Test
+  void extendedHeartbeatHasStableFullSnapshotShape() {
+    assertThat(MetaTelemetry.extendedHeartbeatPayload())
+        .containsEntry("configuration", emptyList())
+        .containsEntry("dependencies", emptyList())
+        .containsEntry("integrations", emptyList());
+  }
+
+  @Test
+  void exportsAppliedIntegrationsRecordedBeforeServiceStarts() throws Exception {
+    QueueingExporter exporter = new QueueingExporter();
+    MetaService service = newService(exporter);
+    MetaIntegrationCollector collector = new MetaIntegrationCollector();
+    try {
+      collector.record(asList("spring-webmvc", "spring-webmvc", "jdbc"));
+      service.start();
+      collector.start(service);
+
+      MetaEvent event = nextEvent(exporter);
+      assertThat(event.getRequestType()).isEqualTo("app-integrations-change");
+      Map<String, Object> spring = new LinkedHashMap<>();
+      spring.put("name", "spring-webmvc");
+      spring.put("enabled", true);
+      Map<String, Object> jdbc = new LinkedHashMap<>();
+      jdbc.put("name", "jdbc");
+      jdbc.put("enabled", true);
+      assertThat(event.getPayload().get("integrations")).isEqualTo(asList(jdbc, spring));
+
+      collector.record(singletonList("servlet"));
+
+      Map<String, Object> servlet = new LinkedHashMap<>();
+      servlet.put("name", "servlet");
+      servlet.put("enabled", true);
+      MetaEvent updated = nextEvent(exporter);
+      assertThat(updated.getPayload().get("integrations")).isEqualTo(asList(jdbc, servlet, spring));
+    } finally {
+      collector.close();
+      service.close();
+    }
+  }
+
+  @Test
+  void exportsEachDependencyLocationOnlyOnce(@TempDir Path tempDir) throws Exception {
+    Path jar = tempDir.resolve("demo.jar");
+    writeMavenJar(jar, "demo");
+    Path loggingJar = tempDir.resolve("logging.jar");
+    writeMavenJar(loggingJar, "logging");
+    Path agentJar = tempDir.resolve("javaagent.jar");
+    writeMavenJar(agentJar, "javaagent");
+    QueueingExporter exporter = new QueueingExporter();
+    MetaService service = newService(exporter);
+    MetaDependencyCollector collector = new MetaDependencyCollector(agentJar.toUri().toURL());
+    try {
+      collector.recordLocation(agentJar.toUri().toURL());
+      collector.recordLocation(jar.toUri().toURL());
+      collector.recordLocation(jar.toUri().toURL());
+      service.start();
+      collector.start(service);
+
+      MetaEvent event = nextEvent(exporter);
+      assertThat(event.getRequestType()).isEqualTo("app-dependencies-loaded");
+      Map<String, Object> dependency = new LinkedHashMap<>();
+      dependency.put("name", "com.example:demo");
+      dependency.put("version", "1.0.0");
+      assertThat(event.getPayload().get("dependencies")).isEqualTo(singletonList(dependency));
+
+      collector.recordLocation(loggingJar.toUri().toURL());
+
+      Map<String, Object> logging = new LinkedHashMap<>();
+      logging.put("name", "com.example:logging");
+      logging.put("version", "1.0.0");
+      MetaEvent updated = nextEvent(exporter);
+      assertThat(updated.getPayload().get("dependencies")).isEqualTo(asList(dependency, logging));
+    } finally {
+      collector.close();
+      service.close();
+    }
+  }
+
+  @Test
+  void retainsNoMoreThanConfiguredDependencyLimit(@TempDir Path tempDir) throws Exception {
+    Path firstJar = tempDir.resolve("first.jar");
+    writeMavenJar(firstJar, "first");
+    Path secondJar = tempDir.resolve("second.jar");
+    writeMavenJar(secondJar, "second");
+    QueueingExporter exporter = new QueueingExporter();
+    MetaService service = newService(exporter);
+    MetaDependencyCollector collector = new MetaDependencyCollector(null, 2, 1);
+    try {
+      collector.recordLocation(firstJar.toUri().toURL());
+      collector.recordLocation(secondJar.toUri().toURL());
+      service.start();
+      collector.start(service);
+
+      MetaEvent event = nextEvent(exporter);
+      Map<String, Object> expectedDependency = new LinkedHashMap<>();
+      expectedDependency.put("name", "com.example:first");
+      expectedDependency.put("version", "1.0.0");
+      assertThat(event.getPayload().get("dependencies"))
+          .isEqualTo(singletonList(expectedDependency));
+      assertThat(collector.snapshot()).hasSize(1);
+    } finally {
+      collector.close();
+      service.close();
+    }
+  }
+
+  private static MetaService newService(MetaExporter exporter) {
+    return new MetaService(exporter, 10, 1_000, "runtime-id", singletonMap("service.name", "test"));
+  }
+
+  private static MetaEvent nextEvent(QueueingExporter exporter) throws InterruptedException {
+    MetaExportRequest request = exporter.requests.poll(5, SECONDS);
+    assertThat(request).isNotNull();
+    assertThat(request.getEvents()).hasSize(1);
+    return request.getEvents().get(0);
+  }
+
+  private static void writeMavenJar(Path path, String artifactId) throws IOException {
+    try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(path))) {
+      output.putNextEntry(new JarEntry("META-INF/maven/com.example/demo/pom.properties"));
+      output.write(
+          ("groupId=com.example\nartifactId=" + artifactId + "\nversion=1.0.0\n")
+              .getBytes(ISO_8859_1));
+      output.closeEntry();
+    }
+  }
+
+  private static final class QueueingExporter implements MetaExporter {
+    private final BlockingQueue<MetaExportRequest> requests = new LinkedBlockingQueue<>();
+
+    @Override
+    public MetaExportResult export(MetaExportRequest request) {
+      requests.add(request);
+      return MetaExportResult.SUCCESS;
+    }
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaConfigurationTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaConfigurationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MetaConfigurationTest {
+
+  @Test
+  void disabledByDefault() {
+    MetaConfiguration configuration =
+        MetaConfiguration.create(DefaultConfigProperties.createFromMap(emptyMap()));
+
+    assertThat(configuration.isEnabled()).isFalse();
+  }
+
+  @Test
+  void readsExporterConfiguration() {
+    Map<String, String> properties = validProperties();
+    properties.put("otel.exporter.meta.headers", "Authorization=Bearer%20token,x-test=value");
+    properties.put("otel.exporter.meta.timeout", "2500");
+    properties.put("otel.exporter.meta.compression", "gzip");
+    properties.put("otel.exporter.meta.max-retries", "4");
+    properties.put("otel.exporter.meta.max-request-size", "1048576");
+    properties.put("otel.meta.batch.schedule-delay", "25");
+    properties.put("otel.meta.shutdown-timeout", "5000");
+    properties.put("otel.meta.heartbeat.interval", "6000");
+    properties.put("otel.meta.extended-heartbeat.interval", "12000");
+    properties.put("otel.meta.app-started.enabled", "false");
+    properties.put("otel.meta.app-dependencies-loaded.enabled", "false");
+    properties.put("otel.meta.app-integrations-change.enabled", "false");
+
+    MetaConfiguration configuration =
+        MetaConfiguration.create(DefaultConfigProperties.createFromMap(properties));
+
+    assertThat(configuration.isEnabled()).isTrue();
+    assertThat(configuration.getEndpoint().toString()).isEqualTo("http://localhost:8080/v1/meta");
+    assertThat(configuration.getHeaders())
+        .containsEntry("Authorization", "Bearer token")
+        .containsEntry("x-test", "value");
+    assertThat(configuration.getTimeoutMillis()).isEqualTo(2500);
+    assertThat(configuration.isGzipEnabled()).isTrue();
+    assertThat(configuration.getMaxRetries()).isEqualTo(4);
+    assertThat(configuration.getMaxRequestSizeBytes()).isEqualTo(1_048_576);
+    assertThat(configuration.getScheduleDelayMillis()).isEqualTo(25);
+    assertThat(configuration.getShutdownTimeoutMillis()).isEqualTo(5000);
+    assertThat(configuration.getHeartbeatIntervalMillis()).isEqualTo(6000);
+    assertThat(configuration.getExtendedHeartbeatIntervalMillis()).isEqualTo(12000);
+    assertThat(configuration.isAppStartedEnabled()).isFalse();
+    assertThat(configuration.isAppDependenciesLoadedEnabled()).isFalse();
+    assertThat(configuration.isAppIntegrationsChangeEnabled()).isFalse();
+  }
+
+  @Test
+  void supportsLegacyBatchExportTimeoutAsShutdownTimeoutAlias() {
+    Map<String, String> properties = validProperties();
+    properties.put("otel.meta.batch.export-timeout", "4321");
+
+    MetaConfiguration configuration =
+        MetaConfiguration.create(DefaultConfigProperties.createFromMap(properties));
+
+    assertThat(configuration.getShutdownTimeoutMillis()).isEqualTo(4321);
+  }
+
+  @Test
+  void enablesAllEventTypesByDefaultWhenMetaExporterIsSelected() {
+    MetaConfiguration configuration =
+        MetaConfiguration.create(DefaultConfigProperties.createFromMap(validProperties()));
+
+    assertThat(configuration.isAppStartedEnabled()).isTrue();
+    assertThat(configuration.isAppDependenciesLoadedEnabled()).isTrue();
+    assertThat(configuration.isAppIntegrationsChangeEnabled()).isTrue();
+    assertThat(configuration.getHeartbeatIntervalMillis()).isEqualTo(60_000);
+    assertThat(configuration.getExtendedHeartbeatIntervalMillis()).isEqualTo(86_400_000);
+  }
+
+  @Test
+  void requiresEndpointWhenMetaExporterIsSelected() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("otel.meta.exporter", "meta");
+
+    assertThatThrownBy(
+            () -> MetaConfiguration.create(DefaultConfigProperties.createFromMap(properties)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("otel.exporter.meta.endpoint");
+  }
+
+  @Test
+  void rejectsInvalidConfiguration() {
+    Map<String, String> invalidShutdownProperties = validProperties();
+    invalidShutdownProperties.put("otel.meta.shutdown-timeout", "0");
+
+    assertThatThrownBy(
+            () ->
+                MetaConfiguration.create(
+                    DefaultConfigProperties.createFromMap(invalidShutdownProperties)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("otel.meta.shutdown-timeout");
+
+    Map<String, String> invalidEndpointProperties = validProperties();
+    invalidEndpointProperties.put("otel.exporter.meta.endpoint", "ftp://localhost/v1/meta");
+    assertThatThrownBy(
+            () ->
+                MetaConfiguration.create(
+                    DefaultConfigProperties.createFromMap(invalidEndpointProperties)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("http or https");
+
+    Map<String, String> invalidHeartbeatProperties = validProperties();
+    invalidHeartbeatProperties.put("otel.meta.heartbeat.interval", "0");
+    assertThatThrownBy(
+            () ->
+                MetaConfiguration.create(
+                    DefaultConfigProperties.createFromMap(invalidHeartbeatProperties)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("otel.meta.heartbeat.interval");
+  }
+
+  @Test
+  void rejectsInvalidOrReservedHeaders() {
+    Map<String, String> reservedHeaderProperties = validProperties();
+    reservedHeaderProperties.put("otel.exporter.meta.headers", "Content-Encoding=gzip");
+    assertThatThrownBy(
+            () ->
+                MetaConfiguration.create(
+                    DefaultConfigProperties.createFromMap(reservedHeaderProperties)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("reserved header");
+
+    Map<String, String> invalidHeaderProperties = validProperties();
+    invalidHeaderProperties.put("otel.exporter.meta.headers", "x-test=first%0Asecond");
+    assertThatThrownBy(
+            () ->
+                MetaConfiguration.create(
+                    DefaultConfigProperties.createFromMap(invalidHeaderProperties)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid HTTP header value");
+  }
+
+  private static Map<String, String> validProperties() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("otel.meta.exporter", "meta");
+    properties.put("otel.exporter.meta.endpoint", "http://localhost:8080/v1/meta");
+    return properties;
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaDependencyResolverTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaDependencyResolverTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MetaDependencyResolverTest {
+
+  @Test
+  void resolvesMavenCoordinatesFromPomProperties(@TempDir Path tempDir) throws Exception {
+    Path jar = tempDir.resolve("renamed.jar");
+    writeJar(
+        jar,
+        null,
+        "META-INF/maven/com.example/demo/pom.properties",
+        "groupId=com.example\nartifactId=demo\nversion=1.2.3\n".getBytes(ISO_8859_1));
+
+    List<MetaDependency> dependencies = MetaDependencyResolver.resolve(jar.toUri().toURL());
+
+    assertThat(dependencies).hasSize(1);
+    assertThat(dependencies.get(0).toPayload())
+        .containsExactlyInAnyOrderEntriesOf(dependencyPayload("com.example:demo", "1.2.3"));
+  }
+
+  @Test
+  void fallsBackToManifestFileNameAndHash(@TempDir Path tempDir) throws Exception {
+    Path jar = tempDir.resolve("fallback-lib-4.5.6.jar");
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    manifest.getMainAttributes().putValue("Implementation-Title", "fallback-lib");
+    writeJar(jar, manifest, "example.txt", new byte[] {1, 2, 3});
+
+    List<MetaDependency> dependencies = MetaDependencyResolver.resolve(jar.toUri().toURL());
+
+    assertThat(dependencies).hasSize(1);
+    assertThat(dependencies.get(0).toPayload())
+        .containsEntry("name", "fallback-lib")
+        .containsEntry("version", "4.5.6");
+    assertThat(dependencies.get(0).toPayload().get("hash").toString()).matches("[0-9A-F]{40}");
+  }
+
+  @Test
+  void ignoresAutomaticModuleNameWhenGuessingFallbackName(@TempDir Path tempDir) throws Exception {
+    Path jar = tempDir.resolve("spring-core-6.1.1.jar");
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    manifest.getMainAttributes().putValue("Automatic-Module-Name", "spring.core");
+    manifest.getMainAttributes().putValue("Implementation-Title", "Spring Core");
+    writeJar(jar, manifest, "example.txt", new byte[] {1});
+
+    List<MetaDependency> dependencies = MetaDependencyResolver.resolve(jar.toUri().toURL());
+
+    assertThat(dependencies).hasSize(1);
+    assertThat(dependencies.get(0).toPayload())
+        .containsEntry("name", "spring-core")
+        .containsEntry("version", "6.1.1");
+  }
+
+  @Test
+  void resolvesDependencyFromNestedJar(@TempDir Path tempDir) throws Exception {
+    byte[] nestedJar =
+        jarBytes(
+            null,
+            "META-INF/maven/org.example/nested/pom.properties",
+            "groupId=org.example\nartifactId=nested\nversion=7.8.9\n".getBytes(ISO_8859_1));
+    Path outerJar = tempDir.resolve("application.jar");
+    writeJar(outerJar, null, "BOOT-INF/lib/nested-7.8.9.jar", nestedJar);
+
+    List<MetaDependency> dependencies =
+        MetaDependencyResolver.resolve(
+            new URL("jar:" + outerJar.toUri() + "!/BOOT-INF/lib/nested-7.8.9.jar!/"));
+
+    assertThat(dependencies).hasSize(1);
+    assertThat(dependencies.get(0).toPayload())
+        .containsExactlyInAnyOrderEntriesOf(dependencyPayload("org.example:nested", "7.8.9"));
+  }
+
+  @Test
+  void resolvesMavenCoordinatesFromExplodedDirectory(@TempDir Path tempDir) throws Exception {
+    Path classes = tempDir.resolve("classes");
+    Path properties = classes.resolve("META-INF/maven/com.example/exploded/pom.properties");
+    Files.createDirectories(properties.getParent());
+    Files.write(
+        properties,
+        "groupId=com.example\nartifactId=exploded\nversion=1.0.0\n".getBytes(ISO_8859_1));
+
+    List<MetaDependency> dependencies = MetaDependencyResolver.resolve(classes.toUri().toURL());
+
+    assertThat(dependencies).hasSize(1);
+    assertThat(dependencies.get(0).toPayload())
+        .containsExactlyInAnyOrderEntriesOf(dependencyPayload("com.example:exploded", "1.0.0"));
+  }
+
+  @Test
+  void rejectsOversizedPomProperties(@TempDir Path tempDir) throws Exception {
+    Path jar = tempDir.resolve("oversized.jar");
+    byte[] content = new byte[65 * 1024];
+    writeJar(jar, null, "META-INF/maven/com.example/demo/pom.properties", content);
+
+    assertThat(MetaDependencyResolver.resolve(jar.toUri().toURL())).isEmpty();
+  }
+
+  private static Map<String, Object> dependencyPayload(String name, String version) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("name", name);
+    payload.put("version", version);
+    return payload;
+  }
+
+  private static void writeJar(Path path, Manifest manifest, String entryName, byte[] content)
+      throws IOException {
+    try (JarOutputStream output =
+        manifest == null
+            ? new JarOutputStream(Files.newOutputStream(path))
+            : new JarOutputStream(Files.newOutputStream(path), manifest)) {
+      output.putNextEntry(new JarEntry(entryName));
+      output.write(content);
+      output.closeEntry();
+    }
+  }
+
+  private static byte[] jarBytes(Manifest manifest, String entryName, byte[] content)
+      throws IOException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (JarOutputStream output =
+        manifest == null ? new JarOutputStream(bytes) : new JarOutputStream(bytes, manifest)) {
+      output.putNextEntry(new JarEntry(entryName));
+      output.write(content);
+      output.closeEntry();
+    }
+    return bytes.toByteArray();
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaInitializerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaInitializerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class MetaInitializerTest {
+
+  @AfterEach
+  void tearDown() {
+    MetaTelemetry.resetForTest();
+  }
+
+  @Test
+  void collectorFailureDoesNotEscapeAgentInitialization() {
+    Instrumentation instrumentation = mock(Instrumentation.class);
+    doThrow(new SecurityException("denied"))
+        .when(instrumentation)
+        .addTransformer(any(ClassFileTransformer.class));
+    Map<String, String> properties = new HashMap<>();
+    properties.put("otel.meta.exporter", "meta");
+    properties.put("otel.exporter.meta.endpoint", "http://127.0.0.1:8889/v1/meta");
+
+    MetaInitializer.initialize(DefaultConfigProperties.createFromMap(properties), instrumentation);
+
+    assertThat(MetaTelemetry.isDisabled()).isTrue();
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaInstallerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaInstallerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class MetaInstallerTest {
+
+  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  @Test
+  void exportsAppStartedWithAllowlistedResource() throws Exception {
+    CountDownLatch received = new CountDownLatch(1);
+    AtomicReference<byte[]> requestBody = new AtomicReference<>();
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    cleanup.deferCleanup(() -> server.stop(0));
+    server.createContext(
+        "/v1/meta",
+        exchange -> {
+          requestBody.set(readAll(exchange.getRequestBody()));
+          exchange.sendResponseHeaders(204, -1);
+          exchange.close();
+          received.countDown();
+        });
+    server.start();
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put("otel.meta.exporter", "meta");
+    properties.put(
+        "otel.exporter.meta.endpoint",
+        "http://127.0.0.1:" + server.getAddress().getPort() + "/v1/meta");
+    properties.put("otel.exporter.meta.max-retries", "0");
+    properties.put("otel.meta.batch.schedule-delay", "10");
+    Resource resource =
+        Resource.create(
+            Attributes.builder()
+                .put(stringKey("service.name"), "checkout")
+                .put(stringKey("service.version"), "1.2.3")
+                .put(stringKey("deployment.environment.name"), "production")
+                .put(stringKey("host.name"), "checkout-host")
+                .put(longKey("process.pid"), 1234)
+                .put(stringKey("process.command_args"), "--secret=value")
+                .build());
+
+    MetaService service =
+        requireNonNull(
+            MetaInstaller.install(
+                DefaultConfigProperties.createFromMap(properties), resource, "2.30.2"));
+    cleanup.deferCleanup(service);
+
+    assertThat(received.await(5, SECONDS)).isTrue();
+    JsonNode root = new ObjectMapper().readTree(new String(requestBody.get(), UTF_8));
+    assertThat(root.get("runtime_id").asText()).isEqualTo(service.getRuntimeId());
+    assertThat(root.get("seq_id").asLong()).isEqualTo(1);
+    assertThat(root.get("tracer_time").asLong()).isPositive();
+    assertThat(root.has("application")).isFalse();
+    assertThat(root.has("host")).isFalse();
+    assertThat(root.get("resource").get("service.name").asText()).isEqualTo("checkout");
+    assertThat(root.get("resource").get("service.version").asText()).isEqualTo("1.2.3");
+    assertThat(root.get("resource").get("deployment.environment.name").asText())
+        .isEqualTo("production");
+    assertThat(root.get("resource").get("telemetry.distro.version").asText()).isEqualTo("2.30.2");
+    assertThat(root.get("resource").get("telemetry.sdk.language").asText()).isEqualTo("java");
+    assertThat(root.get("resource").get("host.name").asText()).isEqualTo("checkout-host");
+    assertThat(root.get("resource").get("host.arch").asText()).isNotEmpty();
+    assertThat(root.get("resource").get("process.runtime.name").asText()).isNotEmpty();
+    assertThat(root.get("resource").get("process.runtime.version").asText()).isNotEmpty();
+    assertThat(root.get("resource").get("process.pid").asLong()).isEqualTo(1234);
+    assertThat(root.get("resource").has("process.command_args")).isFalse();
+    JsonNode event = root.get("events").get(0);
+    assertThat(event.has("sequence_id")).isFalse();
+    assertThat(event.get("request_type").asText()).isEqualTo("app-started");
+    assertThat(event.get("payload").has("agent_version")).isFalse();
+    assertThat(event.get("payload").get("installation_method").asText()).isEqualTo("javaagent");
+    assertThat(event.get("payload").get("startup_status").asText()).isEqualTo("success");
+    JsonNode enabledCapabilities = event.get("payload").get("enabled_capabilities");
+    assertThat(enabledCapabilities.size()).isEqualTo(5);
+    assertThat(enabledCapabilities.get(0).asText()).isEqualTo("app-started");
+    assertThat(enabledCapabilities.get(1).asText()).isEqualTo("app-dependencies-loaded");
+    assertThat(enabledCapabilities.get(2).asText()).isEqualTo("app-integrations-change");
+    assertThat(enabledCapabilities.get(3).asText()).isEqualTo("app-heartbeat");
+    assertThat(enabledCapabilities.get(4).asText()).isEqualTo("app-extended-heartbeat");
+  }
+
+  private static byte[] readAll(InputStream inputStream) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int read;
+    while ((read = inputStream.read(buffer)) >= 0) {
+      outputStream.write(buffer, 0, read);
+    }
+    return outputStream.toByteArray();
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaJsonSerializerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaJsonSerializerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class MetaJsonSerializerTest {
+
+  @Test
+  void serializesVersionedBatchEnvelope() throws Exception {
+    MetaEvent event =
+        new MetaEvent(
+            1234, "app-started", singletonMap("enabled_capabilities", asList("app-started")));
+    MetaExportRequest request =
+        new MetaExportRequest(
+            7, 1235, "runtime-id", singletonMap("service.name", "checkout"), singletonList(event));
+
+    byte[] json = new MetaJsonSerializer().serialize(request);
+    JsonNode root = new ObjectMapper().readTree(new String(json, UTF_8));
+
+    assertThat(root.get("api_version").asText()).isEqualTo("v1");
+    assertThat(root.get("runtime_id").asText()).isEqualTo("runtime-id");
+    assertThat(root.get("seq_id").asLong()).isEqualTo(7);
+    assertThat(root.get("tracer_time").asLong()).isEqualTo(1235);
+    assertThat(root.has("application")).isFalse();
+    assertThat(root.has("host")).isFalse();
+    assertThat(root.get("resource").get("service.name").asText()).isEqualTo("checkout");
+    assertThat(root.get("events")).hasSize(1);
+    JsonNode eventJson = root.get("events").get(0);
+    assertThat(eventJson.has("sequence_id")).isFalse();
+    assertThat(eventJson.get("timestamp").asLong()).isEqualTo(1234);
+    assertThat(eventJson.get("request_type").asText()).isEqualTo("app-started");
+    assertThat(eventJson.get("payload").get("enabled_capabilities").get(0).asText())
+        .isEqualTo("app-started");
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaResourceTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaResourceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MetaResourceTest {
+
+  @Test
+  void combinesRuntimeAndHostMetadataWithoutDdAliases() {
+    Resource source =
+        Resource.create(
+            Attributes.builder()
+                .put(stringKey("service.name"), "checkout")
+                .put(stringKey("service.version"), "1.2.3")
+                .put(stringKey("deployment.environment.name"), "production")
+                .put(stringKey("host.name"), "checkout-host")
+                .put(stringKey("os.description"), "resource-os-description")
+                .put(stringKey("os.kernel.version"), "resource-kernel-version")
+                .build());
+
+    Map<String, Object> resource = MetaResource.from(source, "2.30.2");
+
+    assertThat(resource)
+        .containsEntry("service.name", "checkout")
+        .containsEntry("service.version", "1.2.3")
+        .containsEntry("deployment.environment.name", "production")
+        .containsEntry("telemetry.distro.version", "2.30.2")
+        .containsEntry("telemetry.sdk.language", "java")
+        .containsEntry("host.name", "checkout-host")
+        .containsEntry("os.description", "resource-os-description")
+        .containsEntry("os.kernel.version", "resource-kernel-version")
+        .doesNotContainKeys(
+            "service_name", "service_version", "env", "tracer_version", "hostname", "architecture");
+    assertThat(resource.get("host.arch").toString()).isNotEmpty();
+    assertThat(resource.get("process.runtime.name").toString()).isNotEmpty();
+    assertThat(resource.get("process.runtime.version").toString()).isNotEmpty();
+    assertThat(resource.get("os.type").toString()).isNotEmpty();
+    assertThat(resource.get("os.name").toString()).isNotEmpty();
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaServiceTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaServiceTest.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class MetaServiceTest {
+
+  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  @Test
+  void exportsStateEvent() throws Exception {
+    CapturingExporter exporter = new CapturingExporter(MetaExportResult.SUCCESS);
+    MetaService service =
+        new MetaService(exporter, 10, 1000, "runtime-id", singletonMap("service.name", "checkout"));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("app-started", singletonMap("value", "test"))).isTrue();
+    assertThat(exporter.exported.await(5, SECONDS)).isTrue();
+
+    MetaExportRequest request = exporter.request.get();
+    assertThat(request.getRuntimeId()).isEqualTo("runtime-id");
+    assertThat(request.getSequenceId()).isEqualTo(1);
+    assertThat(request.getResource()).containsEntry("service.name", "checkout");
+    assertThat(request.getEvents()).hasSize(1);
+    assertThat(service.getFailedExports()).isZero();
+  }
+
+  @Test
+  void rejectsUnknownEventType() {
+    MetaService service =
+        new MetaService(
+            request -> MetaExportResult.SUCCESS,
+            10,
+            1000,
+            "runtime-id",
+            singletonMap("service.name", "checkout"));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("custom-event", singletonMap("value", "test"))).isFalse();
+  }
+
+  @Test
+  void countsFailedExport() throws Exception {
+    CapturingExporter exporter = new CapturingExporter(MetaExportResult.PERMANENT_FAILURE);
+    MetaService service =
+        new MetaService(exporter, 10, 1000, "runtime-id", singletonMap("key", "value"));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("app-started", singletonMap("value", "test"))).isTrue();
+    assertThat(exporter.exported.await(5, SECONDS)).isTrue();
+    service.close();
+
+    assertThat(service.getFailedExports()).isEqualTo(1);
+  }
+
+  @Test
+  void retriesFailedAppStartedOnNextHeartbeat() throws Exception {
+    FailingOnceExporter exporter = new FailingOnceExporter();
+    MetaService service =
+        new MetaService(
+            exporter,
+            5,
+            1000,
+            50,
+            10_000,
+            "runtime-id",
+            singletonMap("service.name", "checkout"),
+            Collections::emptyMap);
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("app-started", singletonMap("startup_status", "success"))).isTrue();
+    MetaExportRequest failed = exporter.requests.poll(5, SECONDS);
+    MetaExportRequest retried = exporter.requests.poll(5, SECONDS);
+
+    assertThat(failed).isNotNull();
+    assertThat(failed.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-started");
+    assertThat(retried).isNotNull();
+    assertThat(retried.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-heartbeat", "app-started");
+    assertThat(service.getFailedExports()).isEqualTo(1);
+  }
+
+  @Test
+  void doesNotRetryPermanentlyFailedStateOnNextHeartbeat() throws Exception {
+    FailingOnceExporter exporter = new FailingOnceExporter(MetaExportResult.PERMANENT_FAILURE);
+    MetaService service =
+        new MetaService(
+            exporter,
+            5,
+            1000,
+            50,
+            10_000,
+            "runtime-id",
+            singletonMap("service.name", "checkout"),
+            Collections::emptyMap);
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("app-started", singletonMap("startup_status", "success"))).isTrue();
+    MetaExportRequest failed = exporter.requests.poll(5, SECONDS);
+    MetaExportRequest heartbeat = exporter.requests.poll(5, SECONDS);
+
+    assertThat(failed).isNotNull();
+    assertThat(failed.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-started");
+    assertThat(heartbeat).isNotNull();
+    assertThat(heartbeat.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-heartbeat");
+    assertThat(service.getFailedExports()).isEqualTo(1);
+  }
+
+  @Test
+  void batchesEventsThatArriveWithinScheduleDelay() throws Exception {
+    CapturingExporter exporter = new CapturingExporter(MetaExportResult.SUCCESS);
+    MetaService service =
+        new MetaService(exporter, 200, 1000, "runtime-id", singletonMap("key", "value"));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("app-started", singletonMap("value", 1))).isTrue();
+    assertThat(service.emit("app-dependencies-loaded", singletonMap("value", 2))).isTrue();
+    assertThat(exporter.exported.await(5, SECONDS)).isTrue();
+
+    assertThat(exporter.request.get().getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-started", "app-dependencies-loaded");
+  }
+
+  @Test
+  void retainsOnlyTheLatestFullSnapshotOfEachTypeInABatch() throws Exception {
+    CapturingExporter exporter = new CapturingExporter(MetaExportResult.SUCCESS);
+    MetaService service =
+        new MetaService(exporter, 200, 1000, "runtime-id", singletonMap("key", "value"));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("app-started", singletonMap("value", 1))).isTrue();
+    assertThat(service.emit("app-dependencies-loaded", singletonMap("value", 2))).isTrue();
+    assertThat(service.emit("app-integrations-change", singletonMap("value", 3))).isTrue();
+    assertThat(service.emit("app-dependencies-loaded", singletonMap("value", 4))).isTrue();
+    assertThat(service.emit("app-integrations-change", singletonMap("value", 5))).isTrue();
+    assertThat(exporter.exported.await(5, SECONDS)).isTrue();
+
+    assertThat(exporter.request.get().getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-started", "app-dependencies-loaded", "app-integrations-change");
+    assertThat(exporter.request.get().getEvents().get(1).getPayload()).containsEntry("value", 4);
+    assertThat(exporter.request.get().getEvents().get(2).getPayload()).containsEntry("value", 5);
+  }
+
+  @Test
+  void assignsSequenceToEachExportRequest() throws Exception {
+    QueueingExporter exporter = new QueueingExporter();
+    MetaService service =
+        new MetaService(exporter, 10, 1000, "runtime-id", singletonMap("key", "value"));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    assertThat(service.emit("app-started", singletonMap("value", 1))).isTrue();
+    MetaExportRequest first = exporter.requests.poll(5, SECONDS);
+    assertThat(first).isNotNull();
+
+    assertThat(service.emit("app-dependencies-loaded", singletonMap("value", 2))).isTrue();
+    MetaExportRequest second = exporter.requests.poll(5, SECONDS);
+    assertThat(second).isNotNull();
+
+    assertThat(first.getSequenceId()).isEqualTo(1);
+    assertThat(second.getSequenceId()).isEqualTo(2);
+  }
+
+  @Test
+  void emitsLightweightHeartbeatAtConfiguredInterval() throws Exception {
+    QueueingExporter exporter = new QueueingExporter();
+    MetaService service =
+        new MetaService(
+            exporter,
+            5,
+            1000,
+            20,
+            10_000,
+            "runtime-id",
+            singletonMap("service.name", "checkout"),
+            Collections::emptyMap);
+    cleanup.deferCleanup(service);
+    service.start();
+
+    MetaExportRequest request = exporter.requests.poll(5, SECONDS);
+
+    assertThat(request).isNotNull();
+    assertThat(request.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-heartbeat");
+    assertThat(request.getEvents().get(0).getPayload()).isEmpty();
+    assertThat(request.getResource()).containsEntry("service.name", "checkout");
+  }
+
+  @Test
+  void emitsExtendedHeartbeatWithFullCurrentSnapshots() throws Exception {
+    QueueingExporter exporter = new QueueingExporter();
+    Map<String, Object> snapshot =
+        singletonMap("dependencies", singletonList(singletonMap("name", "demo")));
+    MetaService service =
+        new MetaService(
+            exporter,
+            5,
+            1000,
+            10_000,
+            20,
+            "runtime-id",
+            singletonMap("service.name", "checkout"),
+            () -> snapshot);
+    cleanup.deferCleanup(service);
+    service.start();
+
+    MetaExportRequest request = exporter.requests.poll(5, SECONDS);
+
+    assertThat(request).isNotNull();
+    assertThat(request.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-extended-heartbeat");
+    assertThat(request.getEvents().get(0).getPayload()).isEqualTo(snapshot);
+  }
+
+  @Test
+  void retriesFailedExtendedHeartbeatOnNextOrdinaryHeartbeat() throws Exception {
+    FailingOnceExporter exporter = new FailingOnceExporter();
+    MetaService service =
+        new MetaService(
+            exporter,
+            5,
+            1000,
+            800,
+            500,
+            "runtime-id",
+            singletonMap("service.name", "checkout"),
+            () -> singletonMap("dependencies", emptyList()));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    MetaExportRequest failed = exporter.requests.poll(5, SECONDS);
+    MetaExportRequest retried = exporter.requests.poll(5, SECONDS);
+
+    assertThat(failed).isNotNull();
+    assertThat(failed.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-extended-heartbeat");
+    assertThat(retried).isNotNull();
+    assertThat(retried.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-heartbeat", "app-extended-heartbeat");
+    assertThat(service.getFailedExports()).isEqualTo(1);
+  }
+
+  @Test
+  void exportsLatestStateObservedDuringInFlightRequest() throws Exception {
+    BlockingFirstExporter exporter = new BlockingFirstExporter();
+    MetaService service =
+        new MetaService(exporter, 5, 1000, "runtime-id", singletonMap("key", "value"));
+    cleanup.deferCleanup(service);
+    service.start();
+
+    try {
+      assertThat(service.emit("app-started", singletonMap("value", 1))).isTrue();
+      assertThat(exporter.firstExportStarted.await(5, SECONDS)).isTrue();
+      assertThat(service.emit("app-dependencies-loaded", singletonMap("value", 2))).isTrue();
+      assertThat(service.emit("app-dependencies-loaded", singletonMap("value", 3))).isTrue();
+    } finally {
+      exporter.releaseFirstExport.countDown();
+    }
+
+    MetaExportRequest first = exporter.requests.poll(5, SECONDS);
+    MetaExportRequest second = exporter.requests.poll(5, SECONDS);
+    assertThat(first.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-started");
+    assertThat(second.getEvents())
+        .extracting(MetaEvent::getRequestType)
+        .containsExactly("app-dependencies-loaded");
+    assertThat(second.getEvents().get(0).getPayload()).containsEntry("value", 3);
+  }
+
+  @Test
+  void shutdownTimeoutOnlyBoundsCallerWait() throws Exception {
+    UninterruptibleExporter exporter = new UninterruptibleExporter();
+    MetaService service =
+        new MetaService(exporter, 5, 25, "runtime-id", singletonMap("key", "value"));
+    service.start();
+    assertThat(service.emit("app-started", singletonMap("value", 1))).isTrue();
+    assertThat(exporter.exportStarted.await(5, SECONDS)).isTrue();
+
+    long startedAt = System.nanoTime();
+    try {
+      service.close();
+      assertThat(System.nanoTime() - startedAt).isLessThan(SECONDS.toNanos(1));
+      assertThat(exporter.exportFinished.getCount()).isEqualTo(1);
+    } finally {
+      exporter.releaseExport.countDown();
+    }
+    assertThat(exporter.exportFinished.await(5, SECONDS)).isTrue();
+  }
+
+  private static final class CapturingExporter implements MetaExporter {
+    private final MetaExportResult result;
+    private final CountDownLatch exported = new CountDownLatch(1);
+    private final AtomicReference<MetaExportRequest> request = new AtomicReference<>();
+
+    private CapturingExporter(MetaExportResult result) {
+      this.result = result;
+    }
+
+    @Override
+    public MetaExportResult export(MetaExportRequest request) {
+      this.request.set(request);
+      exported.countDown();
+      return result;
+    }
+  }
+
+  private static final class QueueingExporter implements MetaExporter {
+    private final BlockingQueue<MetaExportRequest> requests = new LinkedBlockingQueue<>();
+
+    @Override
+    public MetaExportResult export(MetaExportRequest request) {
+      requests.add(request);
+      return MetaExportResult.SUCCESS;
+    }
+  }
+
+  private static final class FailingOnceExporter implements MetaExporter {
+    private final BlockingQueue<MetaExportRequest> requests = new LinkedBlockingQueue<>();
+    private final AtomicInteger attempts = new AtomicInteger();
+    private final MetaExportResult firstResult;
+
+    private FailingOnceExporter() {
+      this(MetaExportResult.RETRYABLE_FAILURE);
+    }
+
+    private FailingOnceExporter(MetaExportResult firstResult) {
+      this.firstResult = firstResult;
+    }
+
+    @Override
+    public MetaExportResult export(MetaExportRequest request) {
+      requests.add(request);
+      return attempts.getAndIncrement() == 0 ? firstResult : MetaExportResult.SUCCESS;
+    }
+  }
+
+  private static final class BlockingFirstExporter implements MetaExporter {
+    private final BlockingQueue<MetaExportRequest> requests = new LinkedBlockingQueue<>();
+    private final CountDownLatch firstExportStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseFirstExport = new CountDownLatch(1);
+    private final AtomicInteger attempts = new AtomicInteger();
+
+    @Override
+    @SuppressWarnings("Interruption") // The test exporter restores interruption before returning.
+    public MetaExportResult export(MetaExportRequest request) {
+      requests.add(request);
+      if (attempts.getAndIncrement() == 0) {
+        firstExportStarted.countDown();
+        try {
+          releaseFirstExport.await();
+        } catch (InterruptedException ignored) {
+          Thread.currentThread().interrupt();
+          return MetaExportResult.RETRYABLE_FAILURE;
+        }
+      }
+      return MetaExportResult.SUCCESS;
+    }
+  }
+
+  private static final class UninterruptibleExporter implements MetaExporter {
+    private final CountDownLatch exportStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseExport = new CountDownLatch(1);
+    private final CountDownLatch exportFinished = new CountDownLatch(1);
+
+    @Override
+    @SuppressWarnings("Interruption") // Deliberately simulates an I/O call that ignores interrupts.
+    public MetaExportResult export(MetaExportRequest request) {
+      exportStarted.countDown();
+      boolean released = false;
+      while (!released) {
+        try {
+          releaseExport.await();
+          released = true;
+        } catch (InterruptedException ignored) {
+          // Keep waiting to verify that MetaService.close() still returns after its configured
+          // caller wait timeout.
+        }
+      }
+      exportFinished.countDown();
+      return MetaExportResult.SUCCESS;
+    }
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaTelemetryTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaTelemetryTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MetaTelemetryTest {
+
+  @Test
+  void keepsNestedTransformationsIsolatedByTypeName() {
+    MetaTelemetry.PendingIntegrations pending = new MetaTelemetry.PendingIntegrations();
+
+    pending.add("example.Outer", "outer-instrumentation");
+    pending.add("example.Inner", "inner-instrumentation");
+
+    assertThat(pending.remove("example.Inner")).containsExactly("inner-instrumentation");
+    assertThat(pending.remove("example.Unrelated")).isNull();
+    assertThat(pending.remove("example.Outer")).containsExactly("outer-instrumentation");
+  }
+
+  @Test
+  void combinesMultipleInstrumentationsForTheSameType() {
+    MetaTelemetry.PendingIntegrations pending = new MetaTelemetry.PendingIntegrations();
+
+    pending.add("example.Application", "servlet");
+    pending.add("example.Application", "spring-webmvc");
+    pending.add("example.Application", "servlet");
+
+    assertThat(pending.remove("example.Application")).containsExactly("servlet", "spring-webmvc");
+    assertThat(pending.remove("example.Application")).isNull();
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaTransformationListenerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/meta/MetaTransformationListenerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.meta;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MetaTransformationListenerTest {
+
+  @BeforeEach
+  @AfterEach
+  void resetMetaTelemetry() {
+    MetaTelemetry.resetForTest();
+  }
+
+  @Test
+  void exportsIntegrationOnlyAfterByteBuddyReportsSuccessfulTransformation() throws Exception {
+    Instrumentation instrumentation = ByteBuddyAgent.install();
+    MetaTelemetry.initialize(integrationOnlyConfiguration(), instrumentation);
+    QueueingExporter exporter = new QueueingExporter();
+    MetaService service =
+        new MetaService(exporter, 10, 1_000, "runtime-id", singletonMap("service.name", "test"));
+    service.start();
+    MetaTelemetry.start(service);
+
+    String className =
+        "io.opentelemetry.javaagent.tooling.meta.Generated"
+            + UUID.randomUUID().toString().replace("-", "");
+    ClassFileTransformer transformer =
+        new AgentBuilder.Default()
+            .with(new MetaTransformationListener())
+            .type(named(className))
+            .transform(
+                (builder, typeDescription, classLoader, module, protectionDomain) -> {
+                  MetaTelemetry.integrationMatched(typeDescription.getName(), "test-integration");
+                  return builder.defineField("instrumented", boolean.class, Visibility.PUBLIC);
+                })
+            .installOn(instrumentation);
+    try {
+      Class<?> transformed =
+          new ByteBuddy()
+              .subclass(Object.class)
+              .name(className)
+              .make()
+              .load(getClass().getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
+              .getLoaded();
+
+      assertThat(transformed.getField("instrumented")).isNotNull();
+      MetaExportRequest request = exporter.requests.poll(5, SECONDS);
+      assertThat(request).isNotNull();
+      assertThat(request.getEvents()).hasSize(1);
+      MetaEvent event = request.getEvents().get(0);
+      assertThat(event.getRequestType()).isEqualTo("app-integrations-change");
+      Map<String, Object> integration = new LinkedHashMap<>();
+      integration.put("name", "test-integration");
+      integration.put("enabled", true);
+      assertThat(event.getPayload().get("integrations")).isEqualTo(singletonList(integration));
+    } finally {
+      instrumentation.removeTransformer(transformer);
+      MetaTelemetry.shutdown(service);
+    }
+  }
+
+  private static MetaConfiguration integrationOnlyConfiguration() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("otel.meta.exporter", "meta");
+    properties.put("otel.exporter.meta.endpoint", "http://127.0.0.1:8889/v1/meta");
+    properties.put("otel.meta.app-started.enabled", "false");
+    properties.put("otel.meta.app-dependencies-loaded.enabled", "false");
+    properties.put("otel.meta.app-integrations-change.enabled", "true");
+    return MetaConfiguration.create(DefaultConfigProperties.createFromMap(properties));
+  }
+
+  private static final class QueueingExporter implements MetaExporter {
+    private final BlockingQueue<MetaExportRequest> requests = new LinkedBlockingQueue<>();
+
+    @Override
+    public MetaExportResult export(MetaExportRequest request) {
+      requests.add(request);
+      return MetaExportResult.SUCCESS;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a dedicated Meta HTTP exporter independent of traces, metrics, and logs
- report `app-started`, `app-dependencies-loaded`, `app-integrations-change`, `app-heartbeat`, and `app-extended-heartbeat`
- consolidate application, runtime, host, and agent identity into OpenTelemetry resource attributes
- discover loaded dependencies from Maven metadata, manifests, class directories, and Spring Boot nested JARs
- attribute successfully applied instrumentations and export full latest-state snapshots
- support configurable endpoint, headers, timeout, gzip, bounded request size, retries, batching, heartbeat intervals, and shutdown flushing
- add success/failure logging with sanitized endpoints and document the protocol and configuration

## Reliability and resource bounds

- keep only the latest dependency and integration snapshots instead of an unbounded event queue
- resolve and hash dependencies off class transformation threads
- cap observed locations and retained dependencies at 1,024
- bound both uncompressed JSON and compressed request bodies
- retry transient HTTP/network failures while dropping permanent failures

## Testing

- `./gradlew :javaagent-tooling:check -Dorg.gradle.java.home=/home/liurui/middleware/jdk/jdk-21.0.3`
- verified the shaded Java agent against a Spring Boot application and the local Meta receiver, including gzip, startup, dependency, integration, heartbeat, and extended-heartbeat events

Related discussion: https://github.com/GuanceCloud/opentelemetry-java-instrumentation/discussions/96
